### PR TITLE
gebruik van HalLinks in zoek adres response

### DIFF
--- a/adres-free-text-zoeken.feature
+++ b/adres-free-text-zoeken.feature
@@ -1,0 +1,96 @@
+# language: nl
+Functionaliteit: Adres met free text zoeken
+
+Achtergrond:
+    Gegeven BAG bevat de volgende adressen
+    |keuze item identificatie | straatnaam    | huisnummer | nummeraanduiding id | ado id   | 
+    | 15gaj5y                 | Dalfsenstraat | 1          | NA.1234             | ADO.3456 |
+    | 2354agk                 | Dalfsenstraat | 2          | NA.2345             | ADO.4567 |
+
+Scenario: response in HAL, geen url templating toegepast
+    Als de request GET {baseUrl}/adressen/zoeken?zoekTerm=dalfsenstr wordt verstuurd
+    Dan bevat de response de volgende keuze items met een link om het adres te bevragen
+    """
+    {
+        "_links": {
+            "self": {
+                "href": "/adressen/zoeken?zoekTerm=dalfsenstr"
+            }
+        },
+        "_embedded": {
+            "keuzeItems": [
+                {
+                    "weergaveNaam": "Dalfsenstraat 1",
+                    "_links": {
+                        # keuzeItem is geen resource, daarom geen self HalLink toegevoegd
+                        "adres": {
+                            "href": "/adressen/15gaj5y"
+                        },
+                        "adresMbvNummeraanduidingIdentificatie": {
+                            "href": "/adressen?nummeraanduidingIdentificatie=NA.1234"
+                        },
+                        "adresMbvAdresseerbaarObjecIdentificatie": {
+                            "href": "/adressen?adresseerbaarObjectIdentificatie=ADO.3456"
+                        }
+                    }
+                },
+                {
+                    "weergaveNaam": "Dalfsenstraat 2",
+                    "_links": {
+                        "adres": {
+                            "href": "/adressen/2354agk"
+                        },
+                        "adresMbvNummeraanduidingIdentificatie": {
+                            "href": "/adressen?nummeraanduidingIdentificatie=NA.2345"
+                        },
+                        "adresMbvAdresseerbaarObjecIdentificatie": {
+                            "href": "/adressen?adresseerbaarObjectIdentificatie=ADO.4567"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+    """
+
+Scenario: response in HAL, url templating toegepast
+    Als de request GET {baseUrl}/adressen/zoeken?zoekTerm=dalfsenstr wordt verstuurd
+    Dan bevat de response de volgende keuze items met een link om het adres te bevragen
+    """
+    {
+        "_links": {
+            "self": {
+                "href": "/adressen/zoeken?zoekTerm=dalfsenstr"
+            },
+            "adresMbvTechnischeId": {
+                "href": "/adressen/{technischAdresId}",
+                "templated": true
+            },
+            "adresMbvNummeraanduidingIdentificatie": {
+                "href": "/adressen?nummeraanduidingIdentificatie={nummeraanduidingIdentificatie}",
+                "templated": true
+            },
+            "adresMbvAdresseerbaarObjecIdentificatie": {
+                "href": "/adressen?adresseerbaarObjectIdentificatie={adresseerbaarObjectIdentificatie}",
+                "templated": true
+            }
+        },
+        "_embedded": {
+            # keuzeItem hoeft geen HAL Resource te zijn
+            "keuzeItems": [
+                {
+                    "weergaveNaam": "Dalfsenstraat 1",
+                    "technischAdresId": "15gaj5y",
+                    "nummeraanduidingIdentificatie": "NA.1234"
+                    "adresseerbaarObjectIdentificatie": "ADO.3456"
+                },
+                {
+                    "weergaveNaam": "Dalfsenstraat 2",
+                    "technischAdresId": "2354agk",
+                    "nummeraanduidingIdentificatie": "NA.2345"
+                    "adresseerbaarObjectIdentificatie": "ADO.4567"
+                }
+            ]
+        }
+    }
+    """

--- a/adres-free-text-zoeken.feature
+++ b/adres-free-text-zoeken.feature
@@ -1,57 +1,15 @@
 # language: nl
 Functionaliteit: Adres met free text zoeken
 
+Design Decision:
+Als de response een grote lijst kan bevatten (bijvoorbeeld free text search), dan gebruik maken van url templating en de url opnemen in de root _links.
+Reden: Een url voor elke item in de lijst genereren kost meer tijd en maakt de response onnodig groter
+
 Achtergrond:
     Gegeven BAG bevat de volgende adressen
     |keuze item identificatie | straatnaam    | huisnummer | nummeraanduiding id | ado id   | 
     | 15gaj5y                 | Dalfsenstraat | 1          | NA.1234             | ADO.3456 |
     | 2354agk                 | Dalfsenstraat | 2          | NA.2345             | ADO.4567 |
-
-Scenario: response in HAL, geen url templating toegepast
-    Als de request GET {baseUrl}/adressen/zoeken?zoekTerm=dalfsenstr wordt verstuurd
-    Dan bevat de response de volgende keuze items met een link om het adres te bevragen
-    """
-    {
-        "_links": {
-            "self": {
-                "href": "/adressen/zoeken?zoekTerm=dalfsenstr"
-            }
-        },
-        "_embedded": {
-            "keuzeItems": [
-                {
-                    "weergaveNaam": "Dalfsenstraat 1",
-                    "_links": {
-                        # keuzeItem is geen resource, daarom geen self HalLink toegevoegd
-                        "adres": {
-                            "href": "/adressen/15gaj5y"
-                        },
-                        "adresMbvNummeraanduidingIdentificatie": {
-                            "href": "/adressen?nummeraanduidingIdentificatie=NA.1234"
-                        },
-                        "adresMbvAdresseerbaarObjecIdentificatie": {
-                            "href": "/adressen?adresseerbaarObjectIdentificatie=ADO.3456"
-                        }
-                    }
-                },
-                {
-                    "weergaveNaam": "Dalfsenstraat 2",
-                    "_links": {
-                        "adres": {
-                            "href": "/adressen/2354agk"
-                        },
-                        "adresMbvNummeraanduidingIdentificatie": {
-                            "href": "/adressen?nummeraanduidingIdentificatie=NA.2345"
-                        },
-                        "adresMbvAdresseerbaarObjecIdentificatie": {
-                            "href": "/adressen?adresseerbaarObjectIdentificatie=ADO.4567"
-                        }
-                    }
-                }
-            ]
-        }
-    }
-    """
 
 Scenario: response in HAL, url templating toegepast
     Als de request GET {baseUrl}/adressen/zoeken?zoekTerm=dalfsenstr wordt verstuurd
@@ -65,30 +23,17 @@ Scenario: response in HAL, url templating toegepast
             "adresMbvTechnischeId": {
                 "href": "/adressen/{technischAdresId}",
                 "templated": true
-            },
-            "adresMbvNummeraanduidingIdentificatie": {
-                "href": "/adressen?nummeraanduidingIdentificatie={nummeraanduidingIdentificatie}",
-                "templated": true
-            },
-            "adresMbvAdresseerbaarObjecIdentificatie": {
-                "href": "/adressen?adresseerbaarObjectIdentificatie={adresseerbaarObjectIdentificatie}",
-                "templated": true
             }
         },
         "_embedded": {
-            # keuzeItem hoeft geen HAL Resource te zijn
             "keuzeItems": [
                 {
                     "weergaveNaam": "Dalfsenstraat 1",
-                    "technischAdresId": "15gaj5y",
-                    "nummeraanduidingIdentificatie": "NA.1234"
-                    "adresseerbaarObjectIdentificatie": "ADO.3456"
+                    "technischAdresId": "15gaj5y"
                 },
                 {
                     "weergaveNaam": "Dalfsenstraat 2",
-                    "technischAdresId": "2354agk",
-                    "nummeraanduidingIdentificatie": "NA.2345"
-                    "adresseerbaarObjectIdentificatie": "ADO.4567"
+                    "technischAdresId": "2354agk"
                 }
             ]
         }

--- a/adres-free-text-zoeken.feature
+++ b/adres-free-text-zoeken.feature
@@ -7,9 +7,9 @@ Reden: Een url voor elke item in de lijst genereren kost meer tijd en maakt de r
 
 Achtergrond:
     Gegeven BAG bevat de volgende adressen
-    |keuze item identificatie | straatnaam    | huisnummer | nummeraanduiding id | ado id   | 
-    | 15gaj5y                 | Dalfsenstraat | 1          | NA.1234             | ADO.3456 |
-    | 2354agk                 | Dalfsenstraat | 2          | NA.2345             | ADO.4567 |
+    |keuze item identificatie | straatnaam    | huisnummer |
+    | 15gaj5y                 | Dalfsenstraat | 1          |
+    | 2354agk                 | Dalfsenstraat | 2          |
 
 Scenario: response in HAL, url templating toegepast
     Als de request GET {baseUrl}/adressen/zoeken?zoekTerm=dalfsenstr wordt verstuurd


### PR DESCRIPTION
De feature file visualiseert (hoop ik) het wel/niet toepassen van url templating
Voordeel van toepassen van url templating is dat je niet elke Resource een HAL variant hoeft te maken
En je hoeft url templating niet bij elke Resource toe te passen. Ik denk dat url templating vooral voordelen levert bij lijsten (geen herhaling van urls voor elke item in de lijst) en links naar andere api's die de versie opnemen in de url