### PR TITLE
Johan boer diverse kleine aanpassingen

### DIFF
--- a/api-specificatie/openapi.yaml
+++ b/api-specificatie/openapi.yaml
@@ -44,11 +44,7 @@ paths:
               schema:
                 $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/master/api-specificatie/generiek/api-info.yaml#/API-info'
         default:
-          description: 'Onverwacht probleem'
-          content:
-            application/problem+json:
-              schema:
-                $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/Foutbericht'
+          $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/default'
 
   /adressen/zoek:
     get:
@@ -911,7 +907,6 @@ components:
         - properties:
             _links:
               $ref: '#/components/schemas/ZoekResultaat_links'
-
     ZoekResultaat_links:
       type: object
       properties:
@@ -921,8 +916,6 @@ components:
           type: array
           items:
             $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink'
-          minItems: 1
-
     ZoekResultaatHalCollectie:
       type: object
       description: 'resulaten als lijst'
@@ -997,7 +990,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/NEN3610ID'
-          minItems: 1
         indicatieNevenadres:
           description: 'Een aanduiding die aangeeft of dit adres een nevenadres is van een adresseerbaar object. Als deze boolean niet wordt meegeleverd (of als deze false is) dan is dit een Hoofdadres.'
           type: boolean
@@ -1021,8 +1013,6 @@ components:
             $ref: '#/components/schemas/Adres_links'
     Adres_links:
       type: object
-      required:
-        - self
       properties:
         self:
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink'
@@ -1043,8 +1033,6 @@ components:
           type: array
           items:
             $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink'
-          minItems: 1
-
     Adres_embedded:
       type: object
       properties:
@@ -1062,7 +1050,7 @@ components:
           description: unieke identificatie van het adresseerbaar object
           type: string
           example: "01230167890123456"
-        adresseerbaarObjectType:
+        type:
           $ref: '#/components/schemas/TypeAdresseerbaarObject_enum'
         documentdatum:
           description: De datum waarop het brondocument is vastgesteld, op basis waarvan
@@ -1081,7 +1069,7 @@ components:
           type: string
         gebruiksdoel:
           items:
-            $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/master/api-specificatie/lvbag/imbag/v20180601/verblijfsobject.yaml#/Gebruiksdoel'
+            $ref: '#/components/schemas/Gebruiksdoel_enum'
           type: array
         geconstateerd:
           description: Een aanduiding waarmee kan worden aangegeven dat een object
@@ -1090,7 +1078,7 @@ components:
             voor deze opname.
           type: boolean
         geometrie:
-          $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/master/api-specificatie/lvbag/imbag/v20180601/geometrie.yaml#/components/schemas/PuntOfVlak'
+          $ref: '#/components/schemas/PuntOfVlak'
         hoofdAdresIdentificatie:
           description: identificatie van het hoofdadres
           type: string
@@ -1195,17 +1183,32 @@ components:
               $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink'
           type: object
     AdresseerbaarObjectStatus_enum:
+      type: string
       enum:
-      - Verblijfsobject gevormd
-      - Niet gerealiseerd verblijfsobject
-      - Verblijfsobject in gebruik (niet ingemeten)
-      - Verblijfsobject in gebruik
-      - Verbouwing verblijfsobject
-      - Verblijfsobject ingetrokken
-      - Verblijfsobject buiten gebruik
-      - Verblijfsobject ten onrechte opgevoerd
-      - Plaats aangewezen
-      - Plaats ingetrokken
+        # Ligplaats / standplaats huidige statussen
+        - 'Plaats aangewezen'
+        # Verblijfsobject huidige statussen
+        - 'Verblijfsobject gevormd'
+        - 'Verblijfsobject in gebruik (niet ingemeten)'
+        - 'Verblijfsobject in gebruik'
+        - 'Verbouwing verblijfsobject'
+        - 'Verblijfsobject buiten gebruik'
+    Gebruiksdoel_enum:
+      type: string
+      enum:
+        - 'woonfunctie'
+        - 'bijeenkomstfunctie'
+        - 'celfunctie'
+        - 'gezondheidszorgfunctie'
+        - 'industriefunctie'
+        - 'kantoorfunctie'
+        - 'logiesfunctie'
+        - 'onderwijsfunctie'
+        - 'sportfunctie'
+        - 'winkelfunctie'
+        - 'overige gebruiksfunctie'
+
+
     OpenbareRuimte:
       type: object
       title: OpenbareRuimte
@@ -1221,10 +1224,10 @@ components:
           maxLength: 80
           example: 'Laan van de landinrichtingscommissie Duiven-Westervoort'
         type:
-          $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/master/api-specificatie/lvbag/imbag/v20180601/openbareruimte.yaml#/TypeOpenbareRuimte'
+          $ref: '#/components/schemas/TypeOpenbareRuimte_enum'
           description: 'De aard van de als zodanig benoemde openbare ruimte.'
         status:
-          $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/master/api-specificatie/lvbag/imbag/v20180601/datatypes.yaml#/StatusNaamgeving'
+          $ref: '#/components/schemas/StatusNaamgeving_enum'
           desciption: 'De fase van de levenscyclus van een openbare ruimte, waarin de betreffende openbare ruimte zich bevindt.'
         korteNaam:
           title: korteNaam
@@ -1276,8 +1279,6 @@ components:
       
     OpenbareRuimte_links:
       type: object
-      required:
-        - self
       properties:
         self:
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink'
@@ -1320,7 +1321,7 @@ components:
           type: string
           example: '7500AA'
         status:
-          $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/master/api-specificatie/lvbag/imbag/v20180601/datatypes.yaml#/StatusNaamgeving'
+          $ref: '#/components/schemas/StatusNaamgeving_enum'
         geconstateerd:
           description: "Indicator dat een object in de registratie is opgenomen op basis van een feitelijke constatering, zonder dat er een besluit en brondocument aan ten grondslag ligt."
           type: boolean
@@ -1373,8 +1374,6 @@ components:
             $ref: '#/components/schemas/Nummeraanduiding_embedded'
     Nummeraanduiding_links:
       type: object
-      required:
-        - self
       properties:
         self:
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink'
@@ -1416,7 +1415,7 @@ components:
           maxLength: 80
           example: 'Apeldoorn'
         status:
-          $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/master/api-specificatie/lvbag/imbag/v20180601/woonplaats.yaml#/StatusWoonplaats'
+          $ref: '#/components/schemas/StatusWoonplaats_enum'
           description: 'De fase van de levenscyclus van een woonplaats, waarin de betreffende woonplaats zich bevindt.'
         geconstateerd:
           description: Een aanduiding waarmee kan worden aangegeven dat een object in de registratie is opgenomen als gevolg van een feitelijke constatering, zonder dat er op het moment van opname sprake was van een regulier brondocument voor deze opname.
@@ -1454,8 +1453,6 @@ components:
               $ref: '#/components/schemas/Woonplaats_embedded'
     Woonplaats_links:
       type: object
-      required:
-        - self
       properties:
         self:
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink'
@@ -1464,7 +1461,7 @@ components:
       type: object
       properties:
         geometrie:
-          $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/master/api-specificatie/lvbag/imbag/v20180601/geometrie.yaml#/components/schemas/VlakOfMultivlak'
+          $ref: '#/components/schemas/VlakOfMultivlak'
 
     Pand:
       type: object
@@ -1484,7 +1481,7 @@ components:
           maxLength: 4
           example: '1972'
         status:
-          $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/master/api-specificatie/lvbag/imbag/v20180601/pand.yaml#/StatusPand'
+          $ref: '#/components/schemas/StatusPand_enum'
           description: 'Een codering van de verschillende waarden die de status van een pand kan aannemen.'
         geconstateerd:
           description: Een aanduiding waarmee kan worden aangegeven dat een object in de registratie is opgenomen als gevolg van een feitelijke constatering, zonder dat er op het moment van opname sprake was van een regulier brondocument voor deze opname.
@@ -1527,7 +1524,6 @@ components:
           type: array
           items:
             $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink'
-          minItems: 1
 
     Pand_embedded:
       type: object
@@ -1549,13 +1545,53 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/PandHal'
+    StatusNaamgeving_enum:
+      description: Een aanduiding van alle waarden die de status van een openbare ruimte of een nummeraanduiding kan aannemen.
+      type: string
+      enum:
+        - 'Naamgeving uitgegeven'
+        - 'Naamgeving ingetrokken'
+    StatusPand_enum:
+      description: Een codering van de verschillende waarden die de status van een pand kan aannemen.
+      type: string
+      enum:
+        - 'Bouwvergunning verleend'
+        - 'Niet gerealiseerd pand'
+        - 'Bouw gestart'
+        - 'Pand in gebruik (niet ingemeten)'
+        - 'Pand in gebruik'
+        - 'Verbouwing pand'
+        - 'Sloopvergunning verleend'
+        - 'Pand gesloopt'
+        - 'Pand buiten gebruik'
+        - 'Pand ten onrechte opgevoerd'
+    StatusWoonplaats_enum:
+      description: Een aanduiding van alle waarden die de status van een woonplaats kan aannemen.
+      type: string
+      enum:
+        - 'Woonplaats aangewezen'
+        - 'Woonplaats ingetrokken'
+    TypeAdresseerbaarObject_enum:
+      type: string
+      enum:
+        - 'verblijfsobject'
+        - 'standplaats'
+        - 'ligplaats'
+    TypeOpenbareRuimte_enum:
+      description: Een codering van de verschillende waarden die de typering van een openbare ruimte kan aannemen.
+      type: string
+      enum:
+        - 'Weg'
+        - 'Water'
+        - 'Spoorbaan'
+        - 'Terrein'
+        - 'Kunstwerk'
+        - 'Landschappelijk gebied'
+        - 'Administratief gebied'
     NEN3610ID:
       type: object
       title: NEN3610ID
       description: 'De identificatie van een (voorkomen van een) object, conform de NEN3610 standaard.'
-      required:
-        - lokaalID
-        - namespace
       properties:
         lokaalID:
           description: 'De identificatie van een BAG object. Deze is 4 cijfers lang voor een woonplaats (waarde: 0001-9999) en 16 cijfers voor openbare ruimte, nummeraanduiding, verblijfsobject, ligplaats, standplaats en Pand objecten (waarde zoals gespecificeerd in de BAG Catalogus 2018).'
@@ -1568,8 +1604,21 @@ components:
           type: string
           minLength: 1
           example: 'NL.IMBAG.Woonplaats'
-    TypeAdresseerbaarObject_enum:
-      enum:
-      - verblijfsobject
-      - standplaats
-      - ligplaats
+    PuntOfVlak:
+      title: PuntOfVlak
+      type: object
+      description: Een samengesteld geometriegegevenstype waarbij wordt afgedwongen dat voor de geometrie een keuze gemaakt moet worden tussen een punt of een vlak.
+      properties:
+        punt:
+          $ref: 'http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/pointGeoJSON.yaml'
+        vlak:
+          $ref: 'http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/polygonGeoJSON.yaml'
+    VlakOfMultivlak:
+      title: VlakOfMultivlak
+      type: object
+      description: Een samengesteld geometriegegevenstype waarbij wordt afgedwongen dat voor de geometrie een keuze gemaakt moet worden tussen een vlak (GM_Surface) of een multivlak (GM_MultiSurface).
+      properties:
+        vlak:
+          $ref: 'http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/polygonGeoJSON.yaml'
+        multivlak:
+          $ref: 'http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/geometrycollectionGeoJSON.yaml'

--- a/api-specificatie/resolved/openapi.yaml
+++ b/api-specificatie/resolved/openapi.yaml
@@ -67,8 +67,6 @@ paths:
         in: query
         description: Pagina nummer
         required: false
-        style: form
-        explode: true
         schema:
           minimum: 1
           type: integer
@@ -76,8 +74,6 @@ paths:
       - name: pageSize
         in: query
         required: false
-        style: form
-        explode: true
         schema:
           maximum: 100
           minimum: 1
@@ -339,8 +335,6 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: fields
@@ -352,16 +346,12 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
-        style: simple
-        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -658,8 +648,6 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: fields
@@ -671,16 +659,12 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
-        style: simple
-        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -976,8 +960,6 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: fields
@@ -989,16 +971,12 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
-        style: simple
-        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -1305,8 +1283,6 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: fields
@@ -1318,16 +1294,12 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
-        style: simple
-        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -1620,8 +1592,6 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: fields
@@ -1633,16 +1603,12 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
-        style: simple
-        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -1934,8 +1900,6 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: fields
@@ -1947,8 +1911,6 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       responses:
@@ -2237,8 +2199,6 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: fields
@@ -2250,8 +2210,6 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       responses:
@@ -2538,8 +2496,6 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: fields
@@ -2551,16 +2507,12 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
-        style: simple
-        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -2866,8 +2818,6 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: fields
@@ -2879,16 +2829,12 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
-        style: simple
-        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -3167,8 +3113,6 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: fields
@@ -3180,24 +3124,18 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
-        style: form
-        explode: true
         schema:
           type: string
       - name: Content-Crs
         in: header
         description: CRS van de meegegeven geometrie.
         required: false
-        style: simple
-        explode: false
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
-        style: simple
-        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -3643,6 +3581,7 @@ components:
             een opname, mutatie of een verwijdering van gegevens ten aanzien van een
             object heeft plaatsgevonden.
           format: date
+          example: 2019-08-14
         documentnummer:
           maxLength: 40
           type: string
@@ -3819,6 +3758,7 @@ components:
             een opname, mutatie of een verwijdering van gegevens ten aanzien van een
             object heeft plaatsgevonden.
           format: date
+          example: 2019-08-14
         documentnummer:
           title: documentnummer
           maxLength: 40
@@ -3913,6 +3853,7 @@ components:
             een opname, mutatie of een verwijdering van gegevens ten aanzien van een
             object heeft plaatsgevonden.
           format: date
+          example: 2019-08-14
         documentnummer:
           title: documentnummer
           maxLength: 40
@@ -4005,6 +3946,7 @@ components:
             een opname, mutatie of een verwijdering van gegevens ten aanzien van een
             object heeft plaatsgevonden.
           format: date
+          example: 2019-08-14
         documentnummer:
           title: documentnummer
           maxLength: 40
@@ -4082,6 +4024,7 @@ components:
             een opname, mutatie of een verwijdering van gegevens ten aanzien van een
             object heeft plaatsgevonden.
           format: date
+          example: 2019-08-14
         documentnummer:
           title: documentnummer
           maxLength: 40
@@ -4660,16 +4603,12 @@ components:
         example: "0518300000000001"
   headers:
     api_version:
-      style: simple
-      explode: false
       schema:
         type: string
         description: Geeft een specifieke API-versie aan in de context van een specifieke
           aanroep.
         example: 1.0.0
     warning:
-      style: simple
-      explode: false
       schema:
         type: string
         description: zie RFC 7234. In het geval een major versie wordt uitgefaseerd,
@@ -4680,39 +4619,26 @@ components:
           en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie
           hier de documentatie: https://omgevingswet.../api/.../v1".'
     X_Rate_Limit_Limit:
-      style: simple
-      explode: false
       schema:
         type: integer
     X_Rate_Limit_Remaining:
-      style: simple
-      explode: false
       schema:
         type: integer
     X_Rate_Limit_Reset:
-      style: simple
-      explode: false
       schema:
         type: integer
     X_Pagination_Page:
-      style: simple
-      explode: false
       schema:
         type: integer
         description: Huidige pagina.
         example: 3
     X_Pagination_Limit:
-      style: simple
-      explode: false
       schema:
         type: integer
         description: Aantal resultaten per pagina.
         example: 20
     contentCrs:
       description: CRS van de meegegeven geometrie.
-      required: false
-      style: simple
-      explode: false
       schema:
         type: string
   securitySchemes:

--- a/api-specificatie/resolved/openapi.yaml
+++ b/api-specificatie/resolved/openapi.yaml
@@ -67,6 +67,8 @@ paths:
         in: query
         description: Pagina nummer
         required: false
+        style: form
+        explode: true
         schema:
           minimum: 1
           type: integer
@@ -74,6 +76,8 @@ paths:
       - name: pageSize
         in: query
         required: false
+        style: form
+        explode: true
         schema:
           maximum: 100
           minimum: 1
@@ -335,6 +339,8 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: fields
@@ -346,12 +352,16 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
+        style: simple
+        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -648,6 +658,8 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: fields
@@ -659,12 +671,16 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
+        style: simple
+        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -960,6 +976,8 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: fields
@@ -971,12 +989,16 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
+        style: simple
+        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -1283,6 +1305,8 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: fields
@@ -1294,12 +1318,16 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
+        style: simple
+        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -1592,6 +1620,8 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: fields
@@ -1603,12 +1633,16 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
+        style: simple
+        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -1900,6 +1934,8 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: fields
@@ -1911,6 +1947,8 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       responses:
@@ -2199,6 +2237,8 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: fields
@@ -2210,6 +2250,8 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       responses:
@@ -2496,6 +2538,8 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: fields
@@ -2507,12 +2551,16 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
+        style: simple
+        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -2818,6 +2866,8 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: fields
@@ -2829,12 +2879,16 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
+        style: simple
+        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -3113,6 +3167,8 @@ paths:
           van resource kunnen worden opgegeven door het opgeven van de resource-naam
           gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: fields
@@ -3124,18 +3180,24 @@ paths:
           worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie
           [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)
         required: false
+        style: form
+        explode: true
         schema:
           type: string
       - name: Content-Crs
         in: header
         description: CRS van de meegegeven geometrie.
         required: false
+        style: simple
+        explode: false
         schema:
           type: string
       - name: Accept-Crs
         in: header
         description: Gewenste CRS van de coördinaten in de response.
         required: false
+        style: simple
+        explode: false
         schema:
           type: string
           description: CRS van de coördinaten in de response.
@@ -3581,7 +3643,6 @@ components:
             een opname, mutatie of een verwijdering van gegevens ten aanzien van een
             object heeft plaatsgevonden.
           format: date
-          example: 2019-08-14
         documentnummer:
           maxLength: 40
           type: string
@@ -3758,7 +3819,6 @@ components:
             een opname, mutatie of een verwijdering van gegevens ten aanzien van een
             object heeft plaatsgevonden.
           format: date
-          example: 2019-08-14
         documentnummer:
           title: documentnummer
           maxLength: 40
@@ -3853,7 +3913,6 @@ components:
             een opname, mutatie of een verwijdering van gegevens ten aanzien van een
             object heeft plaatsgevonden.
           format: date
-          example: 2019-08-14
         documentnummer:
           title: documentnummer
           maxLength: 40
@@ -3946,7 +4005,6 @@ components:
             een opname, mutatie of een verwijdering van gegevens ten aanzien van een
             object heeft plaatsgevonden.
           format: date
-          example: 2019-08-14
         documentnummer:
           title: documentnummer
           maxLength: 40
@@ -4024,7 +4082,6 @@ components:
             een opname, mutatie of een verwijdering van gegevens ten aanzien van een
             object heeft plaatsgevonden.
           format: date
-          example: 2019-08-14
         documentnummer:
           title: documentnummer
           maxLength: 40
@@ -4603,12 +4660,16 @@ components:
         example: "0518300000000001"
   headers:
     api_version:
+      style: simple
+      explode: false
       schema:
         type: string
         description: Geeft een specifieke API-versie aan in de context van een specifieke
           aanroep.
         example: 1.0.0
     warning:
+      style: simple
+      explode: false
       schema:
         type: string
         description: zie RFC 7234. In het geval een major versie wordt uitgefaseerd,
@@ -4619,20 +4680,30 @@ components:
           en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie
           hier de documentatie: https://omgevingswet.../api/.../v1".'
     X_Rate_Limit_Limit:
+      style: simple
+      explode: false
       schema:
         type: integer
     X_Rate_Limit_Remaining:
+      style: simple
+      explode: false
       schema:
         type: integer
     X_Rate_Limit_Reset:
+      style: simple
+      explode: false
       schema:
         type: integer
     X_Pagination_Page:
+      style: simple
+      explode: false
       schema:
         type: integer
         description: Huidige pagina.
         example: 3
     X_Pagination_Limit:
+      style: simple
+      explode: false
       schema:
         type: integer
         description: Aantal resultaten per pagina.
@@ -4640,6 +4711,8 @@ components:
     contentCrs:
       description: CRS van de meegegeven geometrie.
       required: false
+      style: simple
+      explode: false
       schema:
         type: string
   securitySchemes:

--- a/api-specificatie/resolved/openapi.yaml
+++ b/api-specificatie/resolved/openapi.yaml
@@ -35,7 +35,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/API-info'
         default:
-          description: Onverwacht probleem
+          description: Er is een onverwachte fout opgetreden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
           content:
             application/problem+json:
               schema:
@@ -3428,7 +3431,6 @@ components:
         self:
           $ref: '#/components/schemas/HalLink'
         adressen:
-          minItems: 1
           type: array
           items:
             $ref: '#/components/schemas/HalLink'
@@ -3502,7 +3504,6 @@ components:
         adresseerbaarObjectIdentificatie:
           $ref: '#/components/schemas/NEN3610ID'
         pandIdentificaties:
-          minItems: 1
           type: array
           items:
             $ref: '#/components/schemas/NEN3610ID'
@@ -3539,8 +3540,6 @@ components:
           _links:
             $ref: '#/components/schemas/Adres_links'
     Adres_links:
-      required:
-      - self
       type: object
       properties:
         self:
@@ -3554,7 +3553,6 @@ components:
         adresseerbareObject:
           $ref: '#/components/schemas/HalLink'
         panden:
-          minItems: 1
           type: array
           description: Het/de aan het adres gerelateerde pand(en).
           items:
@@ -3575,7 +3573,7 @@ components:
           type: string
           description: unieke identificatie van het adresseerbaar object
           example: "01230167890123456"
-        adresseerbaarObjectType:
+        type:
           $ref: '#/components/schemas/TypeAdresseerbaarObject_enum'
         documentdatum:
           type: string
@@ -3595,7 +3593,7 @@ components:
         gebruiksdoel:
           type: array
           items:
-            $ref: '#/components/schemas/Gebruiksdoel'
+            $ref: '#/components/schemas/Gebruiksdoel_enum'
         geconstateerd:
           type: boolean
           description: Een aanduiding waarmee kan worden aangegeven dat een object
@@ -3701,16 +3699,26 @@ components:
     AdresseerbaarObjectStatus_enum:
       type: string
       enum:
+      - Plaats aangewezen
       - Verblijfsobject gevormd
-      - Niet gerealiseerd verblijfsobject
       - Verblijfsobject in gebruik (niet ingemeten)
       - Verblijfsobject in gebruik
       - Verbouwing verblijfsobject
-      - Verblijfsobject ingetrokken
       - Verblijfsobject buiten gebruik
-      - Verblijfsobject ten onrechte opgevoerd
-      - Plaats aangewezen
-      - Plaats ingetrokken
+    Gebruiksdoel_enum:
+      type: string
+      enum:
+      - woonfunctie
+      - bijeenkomstfunctie
+      - celfunctie
+      - gezondheidszorgfunctie
+      - industriefunctie
+      - kantoorfunctie
+      - logiesfunctie
+      - onderwijsfunctie
+      - sportfunctie
+      - winkelfunctie
+      - overige gebruiksfunctie
     OpenbareRuimte:
       title: OpenbareRuimte
       type: object
@@ -3726,9 +3734,9 @@ components:
             strekkend formeel gemeentelijk besluit.
           example: Laan van de landinrichtingscommissie Duiven-Westervoort
         type:
-          $ref: '#/components/schemas/TypeOpenbareRuimte'
+          $ref: '#/components/schemas/TypeOpenbareRuimte_enum'
         status:
-          $ref: '#/components/schemas/StatusNaamgeving'
+          $ref: '#/components/schemas/StatusNaamgeving_enum'
         korteNaam:
           title: korteNaam
           maxLength: 24
@@ -3788,8 +3796,6 @@ components:
           _embedded:
             $ref: '#/components/schemas/OpenbareRuimte_embedded'
     OpenbareRuimte_links:
-      required:
-      - self
       type: object
       properties:
         self:
@@ -3834,7 +3840,7 @@ components:
             combinatie van een straatnaam en een huisnummer.
           example: 7500AA
         status:
-          $ref: '#/components/schemas/StatusNaamgeving'
+          $ref: '#/components/schemas/StatusNaamgeving_enum'
         geconstateerd:
           type: boolean
           description: Indicator dat een object in de registratie is opgenomen op
@@ -3893,8 +3899,6 @@ components:
           _embedded:
             $ref: '#/components/schemas/Nummeraanduiding_embedded'
     Nummeraanduiding_links:
-      required:
-      - self
       type: object
       properties:
         self:
@@ -3928,7 +3932,7 @@ components:
           description: De benaming van een door het gemeentebestuur aangewezen woonplaats.
           example: Apeldoorn
         status:
-          $ref: '#/components/schemas/StatusWoonplaats'
+          $ref: '#/components/schemas/StatusWoonplaats_enum'
         geconstateerd:
           type: boolean
           description: Een aanduiding waarmee kan worden aangegeven dat een object
@@ -3976,8 +3980,6 @@ components:
           _embedded:
             $ref: '#/components/schemas/Woonplaats_embedded'
     Woonplaats_links:
-      required:
-      - self
       type: object
       properties:
         self:
@@ -4008,7 +4010,7 @@ components:
             niet tot wijziging van het bouwjaar.
           example: "1972"
         status:
-          $ref: '#/components/schemas/StatusPand'
+          $ref: '#/components/schemas/StatusPand_enum'
         geconstateerd:
           type: boolean
           description: Een aanduiding waarmee kan worden aangegeven dat een object
@@ -4057,7 +4059,6 @@ components:
         self:
           $ref: '#/components/schemas/HalLink'
         adressen:
-          minItems: 1
           type: array
           items:
             $ref: '#/components/schemas/HalLink'
@@ -4075,11 +4076,55 @@ components:
           $ref: '#/components/schemas/HalCollectionLinks'
         _embedded:
           $ref: '#/components/schemas/PandHalCollectie__embedded'
+    StatusNaamgeving_enum:
+      type: string
+      description: Een aanduiding van alle waarden die de status van een openbare
+        ruimte of een nummeraanduiding kan aannemen.
+      enum:
+      - Naamgeving uitgegeven
+      - Naamgeving ingetrokken
+    StatusPand_enum:
+      type: string
+      description: Een codering van de verschillende waarden die de status van een
+        pand kan aannemen.
+      enum:
+      - Bouwvergunning verleend
+      - Niet gerealiseerd pand
+      - Bouw gestart
+      - Pand in gebruik (niet ingemeten)
+      - Pand in gebruik
+      - Verbouwing pand
+      - Sloopvergunning verleend
+      - Pand gesloopt
+      - Pand buiten gebruik
+      - Pand ten onrechte opgevoerd
+    StatusWoonplaats_enum:
+      type: string
+      description: Een aanduiding van alle waarden die de status van een woonplaats
+        kan aannemen.
+      enum:
+      - Woonplaats aangewezen
+      - Woonplaats ingetrokken
+    TypeAdresseerbaarObject_enum:
+      type: string
+      enum:
+      - verblijfsobject
+      - standplaats
+      - ligplaats
+    TypeOpenbareRuimte_enum:
+      type: string
+      description: Een codering van de verschillende waarden die de typering van een
+        openbare ruimte kan aannemen.
+      enum:
+      - Weg
+      - Water
+      - Spoorbaan
+      - Terrein
+      - Kunstwerk
+      - Landschappelijk gebied
+      - Administratief gebied
     NEN3610ID:
       title: NEN3610ID
-      required:
-      - lokaalID
-      - namespace
       type: object
       properties:
         lokaalID:
@@ -4099,12 +4144,28 @@ components:
           example: NL.IMBAG.Woonplaats
       description: De identificatie van een (voorkomen van een) object, conform de
         NEN3610 standaard.
-    TypeAdresseerbaarObject_enum:
-      type: string
-      enum:
-      - verblijfsobject
-      - standplaats
-      - ligplaats
+    PuntOfVlak:
+      title: PuntOfVlak
+      type: object
+      properties:
+        punt:
+          $ref: '#/components/schemas/pointGeoJSON'
+        vlak:
+          $ref: '#/components/schemas/polygonGeoJSON'
+      description: Een samengesteld geometriegegevenstype waarbij wordt afgedwongen
+        dat voor de geometrie een keuze gemaakt moet worden tussen een punt of een
+        vlak.
+    VlakOfMultivlak:
+      title: VlakOfMultivlak
+      type: object
+      properties:
+        vlak:
+          $ref: '#/components/schemas/polygonGeoJSON'
+        multivlak:
+          $ref: '#/components/schemas/geometrycollectionGeoJSON'
+      description: Een samengesteld geometriegegevenstype waarbij wordt afgedwongen
+        dat voor de geometrie een keuze gemaakt moet worden tussen een vlak (GM_Surface)
+        of een multivlak (GM_MultiSurface).
     API-info:
       title: API-info
       type: object
@@ -4237,72 +4298,6 @@ components:
       properties:
         self:
           $ref: '#/components/schemas/HalLink'
-    Gebruiksdoel:
-      title: Gebruiksdoel
-      type: string
-      enum:
-      - woonfunctie
-      - bijeenkomstfunctie
-      - celfunctie
-      - gezondheidszorgfunctie
-      - industriefunctie
-      - kantoorfunctie
-      - logiesfunctie
-      - onderwijsfunctie
-      - sportfunctie
-      - winkelfunctie
-      - overige gebruiksfunctie
-    PuntOfVlak:
-      title: PuntOfVlak
-      type: object
-      properties:
-        punt:
-          $ref: '#/components/schemas/Point'
-        vlak:
-          $ref: '#/components/schemas/Surface'
-      description: Een samengesteld geometriegegevenstype waarbij wordt afgedwongen
-        dat voor de geometrie een keuze gemaakt moet worden tussen een punt of een
-        vlak.
-    TypeOpenbareRuimte:
-      title: TypeOpenbareRuimte
-      type: string
-      description: Een codering van de verschillende waarden die de typering van een
-        openbare ruimte kan aannemen.
-      enum:
-      - Weg
-      - Water
-      - Spoorbaan
-      - Terrein
-      - Kunstwerk
-      - Landschappelijk gebied
-      - Administratief gebied
-    StatusNaamgeving:
-      title: StatusNaamgeving
-      type: string
-      description: Een aanduiding van alle waarden die de status van een openbare
-        ruimte of een nummeraanduiding kan aannemen.
-      enum:
-      - Naamgeving uitgegeven
-      - Naamgeving ingetrokken
-    StatusWoonplaats:
-      title: StatusWoonplaats
-      type: string
-      description: Een aanduiding van alle waarden die de status van een woonplaats
-        kan aannemen.
-      enum:
-      - Woonplaats aangewezen
-      - Woonplaats ingetrokken
-    VlakOfMultivlak:
-      title: VlakOfMultivlak
-      type: object
-      properties:
-        vlak:
-          $ref: '#/components/schemas/Surface'
-        multivlak:
-          $ref: '#/components/schemas/MultiSurface'
-      description: Een samengesteld geometriegegevenstype waarbij wordt afgedwongen
-        dat voor de geometrie een keuze gemaakt moet worden tussen een vlak (GM_Surface)
-        of een multivlak (GM_MultiSurface).
     polygonGeoJSON:
       required:
       - coordinates
@@ -4323,24 +4318,30 @@ components:
               type: array
               items:
                 type: number
-    StatusPand:
-      title: StatusPand
-      type: string
-      description: Een codering van de verschillende waarden die de status van een
-        pand kan aannemen.
-      enum:
-      - Bouwvergunning verleend
-      - Niet gerealiseerd pand
-      - Bouw gestart
-      - Pand in gebruik (niet ingemeten)
-      - Pand in gebruik
-      - Verbouwing pand
-      - Sloopvergunning verleend
-      - Pand gesloopt
-      - Pand buiten gebruik
-      - Pand ten onrechte opgevoerd
-    Point:
-      title: GeoJSON Point
+    geometrycollectionGeoJSON:
+      required:
+      - geometries
+      - type
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - GeometryCollection
+        geometries:
+          type: array
+          items:
+            $ref: '#/components/schemas/geometryGeoJSON'
+    geometryGeoJSON:
+      oneOf:
+      - $ref: '#/components/schemas/pointGeoJSON'
+      - $ref: '#/components/schemas/multipointGeoJSON'
+      - $ref: '#/components/schemas/linestringGeoJSON'
+      - $ref: '#/components/schemas/multilinestringGeoJSON'
+      - $ref: '#/components/schemas/polygonGeoJSON'
+      - $ref: '#/components/schemas/multipolygonGeoJSON'
+      - $ref: '#/components/schemas/geometrycollectionGeoJSON'
+    multipointGeoJSON:
       required:
       - coordinates
       - type
@@ -4349,21 +4350,33 @@ components:
         type:
           type: string
           enum:
-          - Point
+          - MultiPoint
+        coordinates:
+          type: array
+          items:
+            minItems: 2
+            type: array
+            items:
+              type: number
+    linestringGeoJSON:
+      required:
+      - coordinates
+      - type
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - LineString
         coordinates:
           minItems: 2
           type: array
           items:
-            type: number
-      description: 'Deze definitie is gekopieerd van: http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/pointGeoJSON.yaml'
-    Surface:
-      title: Surface
-      example:
-        type: Polygon
-      allOf:
-      - $ref: '#/components/schemas/Polygon'
-    Polygon:
-      title: GeoJSON Polygon
+            minItems: 2
+            type: array
+            items:
+              type: number
+    multilinestringGeoJSON:
       required:
       - coordinates
       - type
@@ -4372,26 +4385,18 @@ components:
         type:
           type: string
           enum:
-          - Polygon
+          - MultiLineString
         coordinates:
           type: array
           items:
-            minItems: 4
+            minItems: 2
             type: array
             items:
               minItems: 2
               type: array
               items:
                 type: number
-      description: 'Deze definitie is gekopieerd van: http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/polygonGeoJSON.yaml'
-    MultiSurface:
-      title: MultiSurface
-      example:
-        type: MultiPolygon
-      allOf:
-      - $ref: '#/components/schemas/MultiPolygon'
-    MultiPolygon:
-      title: GeoJSON MultiPolygon
+    multipolygonGeoJSON:
       required:
       - coordinates
       - type
@@ -4413,7 +4418,6 @@ components:
                 type: array
                 items:
                   type: number
-      description: 'Deze definitie is gekopieerd van: http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/multipolygonGeoJSON.yaml'
     ZoekResultaatHalCollectie__embedded:
       type: object
       properties:


### PR DESCRIPTION
	• Regel 47 : aanpassen uitgewerkte default error naar een verwijzing naar common.yaml
	• Punt of Vlak en Vlak of Multivlak opnemen in de Openapi.yaml en de doorverwijzingen naar de OpenGis definitie laten verwijzen. 
	• Enumeraties opnemen in de Openapi.yaml. --> Ja. Eventueel later in de beheer-omgeveing zaken weer naar een publieke reposity laten verwijzen. 
	• Enumeratie Status overnemen uit versie Mark. 
	• AdresseerbaarObjectType wordt Type. 
	• Opmerking Melvin 
	  Bij de enum moet je nog type: string aan toevoegen om het in de ui te laten werken
	• Required, minitems etc weg. Alleen bij Parameters mag required voorkomen. 

closes #73