### PR TITLE
feature voor vullen mogelijkOnjuist

### DIFF
--- a/features/mogelijkOnjuist.feature
+++ b/features/mogelijkOnjuist.feature
@@ -3,8 +3,8 @@ Functionaliteit: Mogelijk onjuist
   In de resource wordt aangegeven of bepaalde teruggegeven waarden in de resource mogelijk onjuist zijn. Waarden in de resource zijn mogelijk onjuist wanneer er onderzoek wordt gedaan naar de juistheid van onderliggende gegevens in de registratie.
 
   Scenario: wanneer de status van een object in onderzoek is, zijn alle daaruit afgeleide properties van de resource mogelijk onjuist
-    Gegeven een resource adressen wordt opgevraagd
-    En in object nummeraanduiding is gegeven Status nummeraanduiding in onderzoek
+    Gegeven in object nummeraanduiding is gegeven Status nummeraanduiding in onderzoek
+    Als de resource adressen wordt opgevraagd
     Dan bevat het antwoord
       """
           "mogelijkOnjuist": {
@@ -24,8 +24,8 @@ Functionaliteit: Mogelijk onjuist
       """
 
   Scenario: wanneer meerdere properties in de resource afgeleid zijn van hetzelfde gegeven in de registratie zijn al deze properties van de resource mogelijk onjuist
-    Gegeven een resource adressen wordt opgevraagd
-    En in object Woonplaats is gegeven Status woonplaats in onderzoek
+    Gegeven in object Woonplaats is gegeven Status woonplaats in onderzoek
+    Als de resource adressen wordt opgevraagd
     Dan bevat het antwoord
       """
           "mogelijkOnjuist": {
@@ -37,8 +37,8 @@ Functionaliteit: Mogelijk onjuist
 
 
   Abstract Scenario: mogelijkOnjuist wordt gevuld op basis van in onderzoek staan van gegevens in de registratie
-    Gegeven een resource <Resource> wordt opgevraagd
-    En in object <Objecttype> is gegeven <Attribuut in de BAG> in onderzoek
+    Gegeven in object <Objecttype> is gegeven <Attribuut in de BAG> in onderzoek
+    Als de resource <Resource> wordt opgevraagd
     Dan bevat het antwoord in property mogelijkOnjuist de property of properties <mogelijkOnjuist property> met de boolean waarde true
     En bevat het antwoord in property mogelijkOnjuist de property toelichting met een waarde "<toelichting>"
     En bevat het antwoord in property mogelijkOnjuist geen andere properties dan <mogelijkOnjuist property> en toelichting
@@ -76,9 +76,9 @@ Functionaliteit: Mogelijk onjuist
       | Ligplaats        | Heeft als nevenadres                     | adresseerbareobjecten | nevenAdresIdentificaties | Mogelijk is ten onrechte een nevenadres toegekend of ontbreekt de relatie met een nevenadres. |
 
   Abstract Scenario: mogelijkOnjuist vullen bij onderzoek naar de status van het object
-    Gegeven een resource <Resource> wordt opgevraagd
-    En in object <Objecttype> is gegeven status in onderzoek
+    Gegeven in object <Objecttype> is gegeven status in onderzoek
     En in object <Objecttype> heeft status de waarde <Status>
+    Als de resource <Resource> wordt opgevraagd
     Dan bevat het antwoord in property mogelijkOnjuist de property of properties <mogelijkOnjuist property> met de boolean waarde true
     En bevat het antwoord in property mogelijkOnjuist de property toelichting met een waarde "<toelichting>"
     En bevat het antwoord in property mogelijkOnjuist geen andere properties dan <mogelijkOnjuist property> en toelichting
@@ -99,9 +99,9 @@ Functionaliteit: Mogelijk onjuist
       | Verblijfsobject  | Verbouwing verblijfsobject                  | adresseerbareobjecten | status                   | Mogelijk is de verbouwing al afgerond of wordt de verbouwing niet uitgevoerd. |
 
   Scenario: wanneer meerdere gegevens in onderzoek zijn, worden de toelichtingen van beide onderzoeken toegevoegd.
-    Gegeven een resource adressen wordt opgevraagd
-    En in object nummeraanduiding is gegeven huisnummer in onderzoek
+    Gegeven in object nummeraanduiding is gegeven huisnummer in onderzoek
     En in object nummeraanduiding is gegeven huisletter in onderzoek
+    Als de resource adressen wordt opgevraagd
     Dan bevat het antwoord
       """
           "mogelijkOnjuist": {
@@ -115,9 +115,9 @@ Functionaliteit: Mogelijk onjuist
       """
 
     Scenario: mogelijkOnjuist wordt ook geleverd wanneer het gegeven geen waarde heeft
-      Gegeven een resource adressen wordt opgevraagd
-      En in object nummeraanduiding is gegeven huisnummer in onderzoek
+      Gegeven in object nummeraanduiding is gegeven huisnummer in onderzoek
       En in object nummeraanduiding heeft huisletter geen waarde of is leeg
+      Als de resource adressen wordt opgevraagd
       Dan bevat het antwoord geen property huisletter
       En bevat het antwoord
         """
@@ -130,15 +130,15 @@ Functionaliteit: Mogelijk onjuist
         """
 
     Scenario: mogelijkOnjuist wordt niet geleverd voor velden die niet gevraagd zijn met fields
-      Gegeven een resource adressen wordt opgevraagd met fields=postcode,huisnummer
-      En in object Woonplaats is gegeven Status woonplaats in onderzoek
+      Gegeven in object Woonplaats is gegeven Status woonplaats in onderzoek
+      Als de resource adressen wordt opgevraagd met fields=postcode,huisnummer
       Dan bevat het antwoord geen property mogelijkOnjuist
       En bevat het antwoord property postcode met een waarde
       En bevat het antwoord property huisnummer met een waarde
 
     Scenario: mogelijkOnjuist bij objectstatus in onderzoek en gebruik fields
-      Gegeven een resource adressen wordt opgevraagd met fields=postcode,huisnummer
-      En in object nummeraanduiding is gegeven Status nummeraanduiding in onderzoek
+      Gegeven in object nummeraanduiding is gegeven Status nummeraanduiding in onderzoek
+      Als de resource adressen wordt opgevraagd met fields=postcode,huisnummer
       Dan bevat het antwoord
         """
             "mogelijkOnjuist": {

--- a/features/mogelijkOnjuist.feature
+++ b/features/mogelijkOnjuist.feature
@@ -60,13 +60,11 @@ Functionaliteit: Mogelijk onjuist
       | Nummeraanduiding | Ligt aan gerelateerde openbare ruimte    | adressen              | straat,korteNaam,openbareRuimteIdentificatie | Mogelijk verkeerde straat gebruikt. Het adres moet verwijzen naar de straat waaraan het adres ligt. |
       | Pand             | Geometrie                                | panden                | geometrie                | Mogelijk is de locatie van de contouren onjuist. Mogelijk is de contour onjuist, bijvoorbeeld omdat een uitbouw of een gedeeltelijke sloop niet verwerkt is. |
       | Pand             | Bouwjaar                                 | panden                | oorspronkelijkBouwjaar   | Bouwjaar is mogelijk onjuist. |
-      | Pand             | Status                                   | panden                | status                   | De meest voor de handliggende mogelijke onjuistheden zijn: Bouwvergunning verleend: mogelijk is de bouw al gestart; mogelijk is de bouw al gereed; mogelijk is het pand niet gerealiseerd. Niet gerealiseerd pand: mogelijk is het pand toch gerealiseerd. Bouw gestart: mogelijk is de bouw al gereed; mogelijk is het pand niet gerealiseerd. Pand in gebruik (niet ingemeten): mogelijk is de geometrie al ingemeten. Pand in gebruik: mogelijk is het pand nog niet in gebruik; mogelijk is het pand al gesloopt; mogelijk is er een vergunning tot verbouw verleend; mogelijk is er een sloopmelding gedaan. Sloopvergunning verleend: Mogelijk wordt het pand toch niet gesloopt; Mogelijk is het pand al gesloopt. |
       | Verblijfsobject  | Geometrie                                | adresseerbareobjecten | geometrie                | Locatie/contour mogelijk onjuist. |
       | Standplaats      | Geometrie                                | adresseerbareobjecten | geometrie                | Locatie/contour mogelijk onjuist. |
       | Ligplaats        | Geometrie                                | adresseerbareobjecten | geometrie                | Locatie/contour mogelijk onjuist. |
       | Verblijfsobject  | Gebruiksdoel                             | adresseerbareobjecten | gebruiksdoel             | Het gebruiksdoel is mogelijk onjuist. In de BAG wordt het vergunde gebruik geregistreerd. Het gebruiksdoel moet overeenkomen met het gebruik zoals beschreven in de vergunning. |
       | Verblijfsobject  | Oppervlakte                              | adresseerbareobjecten | oppervlakte              | De oppervlakte is mogelijk onjuist. |
-      | Verblijfsobject  | Status                                   | adresseerbareobjecten | status                   | De meest voor de handliggende mogelijke onjuistheden zijn: Bij verblijfsobject gevormd: mogelijk is de bouw al gereed; mogelijk is het verblijfsobject niet gerealiseerd. Niet gerealiseerd verblijfsobject: mogelijk is het verblijfsobject toch gerealiseerd. Verblijfsobject in gebruik (niet ingemeten): mogelijk is de geometrie al ingemeten. Verblijfsobject in gebruik: mogelijk is het verblijfsobject nog niet in gebruik; mogelijk is het verblijfsobject al ingetrokken; mogelijk is er een vergunning tot verbouw verleend. |
       | Standplaats      | Status                                   | adresseerbareobjecten | status                   | De standplaats bestaat mogelijk niet (meer). |
       | Ligplaats        | Status                                   | adresseerbareobjecten | status                   | De ligplaats bestaat mogelijk niet (meer). |
       | Verblijfsobject  | Maakt onderdeel uit van gerelateerd Pand | adresseerbareobjecten | pandIdentificaties       | Verblijfsobject maakt mogelijk deel uit van een ander pand. |
@@ -76,6 +74,29 @@ Functionaliteit: Mogelijk onjuist
       | Verblijfsobject  | Heeft als nevenadres                     | adresseerbareobjecten | nevenAdresIdentificaties | Mogelijk is ten onrechte een nevenadres toegekend of ontbreekt de relatie met een nevenadres. |
       | Standplaats      | Heeft als nevenadres                     | adresseerbareobjecten | nevenAdresIdentificaties | Mogelijk is ten onrechte een nevenadres toegekend of ontbreekt de relatie met een nevenadres. |
       | Ligplaats        | Heeft als nevenadres                     | adresseerbareobjecten | nevenAdresIdentificaties | Mogelijk is ten onrechte een nevenadres toegekend of ontbreekt de relatie met een nevenadres. |
+
+  Abstract Scenario: mogelijkOnjuist vullen bij onderzoek naar de status van het object
+    Gegeven een resource <Resource> wordt opgevraagd
+    En in object <Objecttype> is gegeven status in onderzoek
+    En in object <Objecttype> heeft status de waarde <Status>
+    Dan bevat het antwoord in property mogelijkOnjuist de property of properties <mogelijkOnjuist property> met de boolean waarde true
+    En bevat het antwoord in property mogelijkOnjuist de property toelichting met een waarde "<toelichting>"
+    En bevat het antwoord in property mogelijkOnjuist geen andere properties dan <mogelijkOnjuist property> en toelichting
+
+    Voorbeelden:
+      | Objecttype       | Status                                      | Resource              | mogelijkOnjuist property | toelichting |
+      | Pand             | Bouwvergunning verleend                     | panden                | status                   | Mogelijk is de bouw al gestart, is de bouw al gereed of is het pand niet gerealiseerd. |
+      | Pand             | Niet gerealiseerd pand                      | panden                | status                   | Mogelijk is het pand toch gerealiseerd. |
+      | Pand             | Bouw gestart                                | panden                | status                   | Mogelijk is de bouw al gereed of is het pand niet gerealiseerd. |
+      | Pand             | Pand in gebruik (niet ingemeten)            | panden                | status                   | Mogelijk is de geometrie al ingemeten. |
+      | Pand             | Pand in gebruik                             | panden                | status                   | Mogelijk is het pand nog niet in gebruik, is het pand al gesloopt, is er een vergunning tot verbouw verleend of is er een sloopmelding gedaan. |
+      | Pand             | Sloopvergunning verleend                    | panden                | status                   | Mogelijk wordt het pand toch niet gesloopt of is het pand al gesloopt. |
+      | Pand             | Verbouwing pand                             | panden                | status                   | Mogelijk is de verbouwing al afgerond of wordt de verbouwing niet uitgevoerd. |
+      | Verblijfsobject  | Verblijfsobject gevormd                     | adresseerbareobjecten | status                   | Mogelijk is de bouw al gereed of is het verblijfsobject niet gerealiseerd. |
+      | Verblijfsobject  | Niet gerealiseerd verblijfsobject           | adresseerbareobjecten | status                   | Mogelijk is het verblijfsobject toch gerealiseerd. |
+      | Verblijfsobject  | Verblijfsobject in gebruik (niet ingemeten) | adresseerbareobjecten | status                   | Mogelijk is de geometrie al ingemeten. |
+      | Verblijfsobject  | Verblijfsobject in gebruik                  | adresseerbareobjecten | status                   | Mogelijk is het verblijfsobject nog niet in gebruik, is het verblijfsobject al ingetrokken of is er een vergunning tot verbouw verleend. |
+      | Verblijfsobject  | Verbouwing verblijfsobject                  | adresseerbareobjecten | status                   | Mogelijk is de verbouwing al afgerond of wordt de verbouwing niet uitgevoerd. |
 
   Scenario: wanneer meerdere gegevens in onderzoek zijn, worden de toelichtingen van beide onderzoeken toegevoegd.
     Gegeven een resource adressen wordt opgevraagd

--- a/features/mogelijkOnjuist.feature
+++ b/features/mogelijkOnjuist.feature
@@ -129,7 +129,7 @@ Functionaliteit: Mogelijk onjuist
             }
         """
     Scenario: mogelijkOnjuist wordt geleverd voor velden die gevraagd zijn met fields
-      Gegeven in object Woonplaats is gegeven huisnummer in onderzoek
+      Gegeven in object nummeraanduiding is gegeven huisnummer in onderzoek
       Als de resource adressen wordt opgevraagd met fields=postcode,huisnummer
       Dan bevat het antwoord property mogelijkOnjuist.huisnummer met de waarde true
       En bevat het antwoord geen property mogelijkOnjuist.postcode
@@ -154,3 +154,26 @@ Functionaliteit: Mogelijk onjuist
                 "toelichting": [ "Adres bestaat mogelijk niet (meer)." ]
             }
         """
+
+    Scenario: mogelijkOnjuist properties vragen met fields
+      Gegeven in object nummeraanduiding is gegeven huisnummer in onderzoek
+      En in object nummeraanduiding is gegeven huisletter in onderzoek
+      En in object nummeraanduiding is gegeven postcode niet in onderzoek
+      Als de resource adressen wordt opgevraagd met fields=huisnummer,mogelijkOnjuist.huisletter,mogelijkOnjuist.postcode
+      Dan bevat het antwoord property mogelijkOnjuist.huisnummer met de waarde true
+      En bevat het antwoord property mogelijkOnjuist.huisletter met de waarde true
+      En bevat het antwoord geen property mogelijkOnjuist.postcode
+      En bevat het antwoord property postcode met een waarde
+      En bevat het antwoord property huisnummer met een waarde
+      En bevat het antwoord geen property huisletter
+
+    Scenario: mogelijkOnjuist vragen met fields
+      Gegeven in object nummeraanduiding is gegeven huisnummer in onderzoek
+      En in object nummeraanduiding is gegeven huisletter in onderzoek
+      Als de resource adressen wordt opgevraagd met fields=mogelijkOnjuist
+      Dan bevat het antwoord property mogelijkOnjuist.huisnummer met de waarde true
+      En bevat het antwoord property mogelijkOnjuist.huisletter met de waarde true
+      En bevat het antwoord geen property mogelijkOnjuist.postcode
+      En bevat het antwoord geen property postcode
+      En bevat het antwoord geen property huisnummer
+      En bevat het antwoord geen property huisletter

--- a/features/mogelijkOnjuist.feature
+++ b/features/mogelijkOnjuist.feature
@@ -128,6 +128,13 @@ Functionaliteit: Mogelijk onjuist
                 ]
             }
         """
+    Scenario: mogelijkOnjuist wordt geleverd voor velden die gevraagd zijn met fields
+      Gegeven in object Woonplaats is gegeven huisnummer in onderzoek
+      Als de resource adressen wordt opgevraagd met fields=postcode,huisnummer
+      Dan bevat het antwoord property mogelijkOnjuist.huisnummer met de waarde true
+      En bevat het antwoord geen property mogelijkOnjuist.postcode
+      En bevat het antwoord property postcode met een waarde
+      En bevat het antwoord property huisnummer met een waarde
 
     Scenario: mogelijkOnjuist wordt niet geleverd voor velden die niet gevraagd zijn met fields
       Gegeven in object Woonplaats is gegeven Status woonplaats in onderzoek

--- a/features/mogelijkOnjuist.feature
+++ b/features/mogelijkOnjuist.feature
@@ -4,7 +4,7 @@ Functionaliteit: Mogelijk onjuist
 
   Scenario: wanneer de status van een object in onderzoek is, zijn alle daaruit afgeleide properties van de resource mogelijk onjuist
     Gegeven in object nummeraanduiding is gegeven Status nummeraanduiding in onderzoek
-    Als de resource adressen wordt opgevraagd
+    Als de afgeleide Adres resource wordt opgevraagd
     Dan bevat het antwoord
       """
           "mogelijkOnjuist": {
@@ -25,7 +25,7 @@ Functionaliteit: Mogelijk onjuist
 
   Scenario: wanneer meerdere properties in de resource afgeleid zijn van hetzelfde gegeven in de registratie zijn al deze properties van de resource mogelijk onjuist
     Gegeven in object Woonplaats is gegeven Status woonplaats in onderzoek
-    Als de resource adressen wordt opgevraagd
+    Als de afgeleide Adres resource wordt opgevraagd
     Dan bevat het antwoord
       """
           "mogelijkOnjuist": {
@@ -38,70 +38,70 @@ Functionaliteit: Mogelijk onjuist
 
   Abstract Scenario: mogelijkOnjuist wordt gevuld op basis van in onderzoek staan van gegevens in de registratie
     Gegeven in object <Objecttype> is gegeven <Attribuut in de BAG> in onderzoek
-    Als de resource <Resource> wordt opgevraagd
+    Als de afgeleide <Resource> resource wordt opgevraagd
     Dan bevat het antwoord in property mogelijkOnjuist de property of properties <mogelijkOnjuist property> met de boolean waarde true
     En bevat het antwoord in property mogelijkOnjuist de property toelichting met een waarde "<toelichting>"
     En bevat het antwoord in property mogelijkOnjuist geen andere properties dan <mogelijkOnjuist property> en toelichting
 
     Voorbeelden:
-      | Objecttype       | Attribuut in de BAG                      | Resource              | mogelijkOnjuist property | toelichting |
-      | Woonplaats       | Naam woonplaats                          | adressen              | woonplaats               | Woonplaatsnaam is mogelijk onjuist geschreven. |
-      | Woonplaats       | Status woonplaats                        | adressen              | woonplaats,woonplaatsIdentificatie | Woonplaats bestaat mogelijk niet. |
-      | Woonplaats       | Geometrie                                | adressen              | woonplaats,woonplaatsIdentificatie | Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt. |
-      | Openbare ruimte  | Naam openbare ruimte                     | adressen              | straat,korteNaam         | Straatnaam komt niet overeen met de vermelding in het straatnaambesluit. |
-      | Openbare ruimte  | Status openbare ruimte                   | adressen              | straat,korteNaam,openbareRuimteIdentificatie | Straat bestaat mogelijk niet (meer). |
-      | Openbare ruimte  | Ligt in gerelateerde woonplaats          | adressen              | woonplaats,woonplaatsIdentificatie | Mogelijk verkeerde woonplaats gebruikt. De straat moet verwijzen naar de woonplaats waarin de straat fysiek ligt. |
-      | Nummeraanduiding | Huisnummer                               | adressen              | huisnummer               | Mogelijk is het verkeerde huisnummer geregistreerd. |
-      | Nummeraanduiding | Huisletter                               | adressen              | huisletter               | Mogelijk is ten onrechte een huisletter toegekend, ontbreekt de huisletter ten onrechte, of is een verkeerde huisletter toegekend. |
-      | Nummeraanduiding | Huisnummertoevoeging                     | adressen              | huisnummertoevoeging     | Mogelijk is ten onrechte een huislettertoevoeging toegekend, ontbreekt de huislettertoevoeging ten onrechte, of is een verkeerde huislettertoevoeging toegekend. |
-      | Nummeraanduiding | Postcode                                 | adressen              | postcode                 | Mogelijk is ten onrechte een postcode toegekend, ontbreekt de postcode ten onrechte, of is een verkeerde postcode toegekend. |
-      | Nummeraanduiding | Status nummeraanduiding                  | adressen              | straat,korteNaam,huisnummer,huisletter,huisnummertoevoeging,postcode,woonplaats,nummeraanduidingIdentificatie,woonplaatsIdentificatie,openbareRuimteIdentificatie,adresseerbaarObjectIdentificatie | Adres bestaat mogelijk niet (meer). |
-      | Nummeraanduiding | Ligt in gerelateerde woonplaats          | adressen              | woonplaatsnummeraanduidingIdentificatie | Mogelijk verkeerde woonplaats gebruikt. Het adres moet verwijzen naar de woonplaats waarin het adres fysiek ligt. |
-      | Nummeraanduiding | Ligt aan gerelateerde openbare ruimte    | adressen              | straat,korteNaam,openbareRuimteIdentificatie | Mogelijk verkeerde straat gebruikt. Het adres moet verwijzen naar de straat waaraan het adres ligt. |
-      | Pand             | Geometrie                                | panden                | geometrie                | Mogelijk is de locatie van de contouren onjuist. Mogelijk is de contour onjuist, bijvoorbeeld omdat een uitbouw of een gedeeltelijke sloop niet verwerkt is. |
-      | Pand             | Bouwjaar                                 | panden                | oorspronkelijkBouwjaar   | Bouwjaar is mogelijk onjuist. |
-      | Verblijfsobject  | Geometrie                                | adresseerbareobjecten | geometrie                | Locatie/contour mogelijk onjuist. |
-      | Standplaats      | Geometrie                                | adresseerbareobjecten | geometrie                | Locatie/contour mogelijk onjuist. |
-      | Ligplaats        | Geometrie                                | adresseerbareobjecten | geometrie                | Locatie/contour mogelijk onjuist. |
-      | Verblijfsobject  | Gebruiksdoel                             | adresseerbareobjecten | gebruiksdoel             | Het gebruiksdoel is mogelijk onjuist. In de BAG wordt het vergunde gebruik geregistreerd. Het gebruiksdoel moet overeenkomen met het gebruik zoals beschreven in de vergunning. |
-      | Verblijfsobject  | Oppervlakte                              | adresseerbareobjecten | oppervlakte              | De oppervlakte is mogelijk onjuist. |
-      | Standplaats      | Status                                   | adresseerbareobjecten | status                   | De standplaats bestaat mogelijk niet (meer). |
-      | Ligplaats        | Status                                   | adresseerbareobjecten | status                   | De ligplaats bestaat mogelijk niet (meer). |
-      | Verblijfsobject  | Maakt onderdeel uit van gerelateerd Pand | adresseerbareobjecten | pandIdentificaties       | Verblijfsobject maakt mogelijk deel uit van een ander pand. |
-      | Verblijfsobject  | Heeft als hoofadres                      | adresseerbareobjecten | hoofdAdresIdentificatie  | AdresseerbaarObject heeft mogelijk een verkeerd adres. Het gerelateerde hoofdadres(ID) mag niet worden gewijzigd want is onlosmakelijk met het adresseerbaar object verbonden. Kan alleen opgelost worden door de gegevens van het adres te veranderen, zodat een ander adres ontstaat. |
-      | Standplaats      | Heeft als hoofdadres                     | adresseerbareobjecten | hoofdAdresIdentificatie  | AdresseerbaarObject heeft mogelijk een verkeerd adres. Het gerelateerde hoofdadres(ID) mag niet worden gewijzigd want is onlosmakelijk met het adresseerbaar object verbonden. Kan alleen opgelost worden door de gegevens van het adres te veranderen, zodat een ander adres ontstaat. |
-      | Ligplaats        | Heeft als hoofdadres                     | adresseerbareobjecten | hoofdAdresIdentificatie  | AdresseerbaarObject heeft mogelijk een verkeerd adres. Het gerelateerde hoofdadres(ID) mag niet worden gewijzigd want is onlosmakelijk met het adresseerbaar object verbonden. Kan alleen opgelost worden door de gegevens van het adres te veranderen, zodat een ander adres ontstaat. |
-      | Verblijfsobject  | Heeft als nevenadres                     | adresseerbareobjecten | nevenAdresIdentificaties | Mogelijk is ten onrechte een nevenadres toegekend of ontbreekt de relatie met een nevenadres. |
-      | Standplaats      | Heeft als nevenadres                     | adresseerbareobjecten | nevenAdresIdentificaties | Mogelijk is ten onrechte een nevenadres toegekend of ontbreekt de relatie met een nevenadres. |
-      | Ligplaats        | Heeft als nevenadres                     | adresseerbareobjecten | nevenAdresIdentificaties | Mogelijk is ten onrechte een nevenadres toegekend of ontbreekt de relatie met een nevenadres. |
+      | Objecttype       | Attribuut in de BAG                      | Resource             | mogelijkOnjuist property | toelichting |
+      | Woonplaats       | Naam woonplaats                          | Adres                | woonplaats               | Woonplaatsnaam is mogelijk onjuist geschreven. |
+      | Woonplaats       | Status woonplaats                        | Adres                | woonplaats,woonplaatsIdentificatie | Woonplaats bestaat mogelijk niet. |
+      | Woonplaats       | Geometrie                                | Adres                | woonplaats,woonplaatsIdentificatie | Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt. |
+      | Openbare ruimte  | Naam openbare ruimte                     | Adres                | straat,korteNaam         | Straatnaam komt niet overeen met de vermelding in het straatnaambesluit. |
+      | Openbare ruimte  | Status openbare ruimte                   | Adres                | straat,korteNaam,openbareRuimteIdentificatie | Straat bestaat mogelijk niet (meer). |
+      | Openbare ruimte  | Ligt in gerelateerde woonplaats          | Adres                | woonplaats,woonplaatsIdentificatie | Mogelijk verkeerde woonplaats gebruikt. De straat moet verwijzen naar de woonplaats waarin de straat fysiek ligt. |
+      | Nummeraanduiding | Huisnummer                               | Adres                | huisnummer               | Mogelijk is het verkeerde huisnummer geregistreerd. |
+      | Nummeraanduiding | Huisletter                               | Adres                | huisletter               | Mogelijk is ten onrechte een huisletter toegekend, ontbreekt de huisletter ten onrechte, of is een verkeerde huisletter toegekend. |
+      | Nummeraanduiding | Huisnummertoevoeging                     | Adres                | huisnummertoevoeging     | Mogelijk is ten onrechte een huislettertoevoeging toegekend, ontbreekt de huislettertoevoeging ten onrechte, of is een verkeerde huislettertoevoeging toegekend. |
+      | Nummeraanduiding | Postcode                                 | Adres                | postcode                 | Mogelijk is ten onrechte een postcode toegekend, ontbreekt de postcode ten onrechte, of is een verkeerde postcode toegekend. |
+      | Nummeraanduiding | Status nummeraanduiding                  | Adres                | straat,korteNaam,huisnummer,huisletter,huisnummertoevoeging,postcode,woonplaats,nummeraanduidingIdentificatie,woonplaatsIdentificatie,openbareRuimteIdentificatie,adresseerbaarObjectIdentificatie | Adres   bestaat mogelijk niet (meer). |
+      | Nummeraanduiding | Ligt in gerelateerde woonplaats          | Adres                | woonplaatsnummeraanduidingIdentificatie | Mogelijk verkeerde woonplaats gebruikt. Het adres moet verwijzen naar de woonplaats waarin het adres fysiek ligt. |
+      | Nummeraanduiding | Ligt aan gerelateerde openbare ruimte    | Adres                | straat,korteNaam,openbareRuimteIdentificatie | Mogelijk verkeerde straat gebruikt. Het adres moet verwijzen naar de straat waaraan het adres ligt. |
+      | Pand             | Geometrie                                | Pand                 | geometrie                | Mogelijk is de locatie van de contouren onjuist. Mogelijk is de contour onjuist, bijvoorbeeld omdat een uitbouw of een gedeeltelijke sloop niet verwerkt is. |
+      | Pand             | Bouwjaar                                 | Pand                 | oorspronkelijkBouwjaar   | Bouwjaar is mogelijk onjuist. |
+      | Verblijfsobject  | Geometrie                                | Adresseerbaar object | geometrie                | Locatie/contour mogelijk onjuist. |
+      | Standplaats      | Geometrie                                | Adresseerbaar object | geometrie                | Locatie/contour mogelijk onjuist. |
+      | Ligplaats        | Geometrie                                | Adresseerbaar object | geometrie                | Locatie/contour mogelijk onjuist. |
+      | Verblijfsobject  | Gebruiksdoel                             | Adresseerbaar object | gebruiksdoel             | Het gebruiksdoel is mogelijk onjuist. In de BAG wordt het vergunde gebruik geregistreerd. Het gebruiksdoel moet overeenkomen met het gebruik zoals beschreven in de vergunning. |
+      | Verblijfsobject  | Oppervlakte                              | Adresseerbaar object | oppervlakte              | De oppervlakte is mogelijk onjuist. |
+      | Standplaats      | Status                                   | Adresseerbaar object | status                   | De standplaats bestaat mogelijk niet (meer). |
+      | Ligplaats        | Status                                   | Adresseerbaar object | status                   | De ligplaats bestaat mogelijk niet (meer). |
+      | Verblijfsobject  | Maakt onderdeel uit van gerelateerd Pand | Adresseerbaar object | pandIdentificaties       | Verblijfsobject maakt mogelijk deel uit van een ander pand. |
+      | Verblijfsobject  | Heeft als hoofadres                      | Adresseerbaar object | hoofdAdresIdentificatie  | AdresseerbaarObject heeft mogelijk een verkeerd adres. Het gerelateerde hoofdadres(ID) mag niet worden gewijzigd want is onlosmakelijk met het adresseerbaar object verbonden. Kan alleen opgelost worden door de gegevens van het adres te veranderen, zodat een ander adres ontstaat. |
+      | Standplaats      | Heeft als hoofdadres                     | Adresseerbaar object | hoofdAdresIdentificatie  | AdresseerbaarObject heeft mogelijk een verkeerd adres. Het gerelateerde hoofdadres(ID) mag niet worden gewijzigd want is onlosmakelijk met het adresseerbaar object verbonden. Kan alleen opgelost worden door de gegevens van het adres te veranderen, zodat een ander adres ontstaat. |
+      | Ligplaats        | Heeft als hoofdadres                     | Adresseerbaar object | hoofdAdresIdentificatie  | AdresseerbaarObject heeft mogelijk een verkeerd adres. Het gerelateerde hoofdadres(ID) mag niet worden gewijzigd want is onlosmakelijk met het adresseerbaar object verbonden. Kan alleen opgelost worden door de gegevens van het adres te veranderen, zodat een ander adres ontstaat. |
+      | Verblijfsobject  | Heeft als nevenadres                     | Adresseerbaar object | nevenAdresIdentificaties | Mogelijk is ten onrechte een nevenadres toegekend of ontbreekt de relatie met een nevenadres. |
+      | Standplaats      | Heeft als nevenadres                     | Adresseerbaar object | nevenAdresIdentificaties | Mogelijk is ten onrechte een nevenadres toegekend of ontbreekt de relatie met een nevenadres. |
+      | Ligplaats        | Heeft als nevenadres                     | Adresseerbaar object | nevenAdresIdentificaties | Mogelijk is ten onrechte een nevenadres toegekend of ontbreekt de relatie met een nevenadres. |
 
   Abstract Scenario: mogelijkOnjuist vullen bij onderzoek naar de status van het object
     Gegeven in object <Objecttype> is gegeven status in onderzoek
     En in object <Objecttype> heeft status de waarde <Status>
-    Als de resource <Resource> wordt opgevraagd
+    Als de afgeleide <Resource> resource wordt opgevraagd
     Dan bevat het antwoord in property mogelijkOnjuist de property of properties <mogelijkOnjuist property> met de boolean waarde true
     En bevat het antwoord in property mogelijkOnjuist de property toelichting met een waarde "<toelichting>"
     En bevat het antwoord in property mogelijkOnjuist geen andere properties dan <mogelijkOnjuist property> en toelichting
 
     Voorbeelden:
-      | Objecttype       | Status                                      | Resource              | mogelijkOnjuist property | toelichting |
-      | Pand             | Bouwvergunning verleend                     | panden                | status                   | Mogelijk is de bouw al gestart, is de bouw al gereed of is het pand niet gerealiseerd. |
-      | Pand             | Niet gerealiseerd pand                      | panden                | status                   | Mogelijk is het pand toch gerealiseerd. |
-      | Pand             | Bouw gestart                                | panden                | status                   | Mogelijk is de bouw al gereed of is het pand niet gerealiseerd. |
-      | Pand             | Pand in gebruik (niet ingemeten)            | panden                | status                   | Mogelijk is de geometrie al ingemeten. |
-      | Pand             | Pand in gebruik                             | panden                | status                   | Mogelijk is het pand nog niet in gebruik, is het pand al gesloopt, is er een vergunning tot verbouw verleend of is er een sloopmelding gedaan. |
-      | Pand             | Sloopvergunning verleend                    | panden                | status                   | Mogelijk wordt het pand toch niet gesloopt of is het pand al gesloopt. |
-      | Pand             | Verbouwing pand                             | panden                | status                   | Mogelijk is de verbouwing al afgerond of wordt de verbouwing niet uitgevoerd. |
-      | Verblijfsobject  | Verblijfsobject gevormd                     | adresseerbareobjecten | status                   | Mogelijk is de bouw al gereed of is het verblijfsobject niet gerealiseerd. |
-      | Verblijfsobject  | Niet gerealiseerd verblijfsobject           | adresseerbareobjecten | status                   | Mogelijk is het verblijfsobject toch gerealiseerd. |
-      | Verblijfsobject  | Verblijfsobject in gebruik (niet ingemeten) | adresseerbareobjecten | status                   | Mogelijk is de geometrie al ingemeten. |
-      | Verblijfsobject  | Verblijfsobject in gebruik                  | adresseerbareobjecten | status                   | Mogelijk is het verblijfsobject nog niet in gebruik, is het verblijfsobject al ingetrokken of is er een vergunning tot verbouw verleend. |
-      | Verblijfsobject  | Verbouwing verblijfsobject                  | adresseerbareobjecten | status                   | Mogelijk is de verbouwing al afgerond of wordt de verbouwing niet uitgevoerd. |
+      | Objecttype       | Status                                      | Resource             | mogelijkOnjuist property | toelichting |
+      | Pand             | Bouwvergunning verleend                     | Pand                 | status                   | Mogelijk is de bouw al gestart, is de bouw al gereed of is het pand niet gerealiseerd. |
+      | Pand             | Niet gerealiseerd pand                      | Pand                 | status                   | Mogelijk is het pand toch gerealiseerd. |
+      | Pand             | Bouw gestart                                | Pand                 | status                   | Mogelijk is de bouw al gereed of is het pand niet gerealiseerd. |
+      | Pand             | Pand in gebruik (niet ingemeten)            | Pand                 | status                   | Mogelijk is de geometrie al ingemeten. |
+      | Pand             | Pand in gebruik                             | Pand                 | status                   | Mogelijk is het pand nog niet in gebruik, is het pand al gesloopt, is er een vergunning tot verbouw verleend of is er een sloopmelding gedaan. |
+      | Pand             | Sloopvergunning verleend                    | Pand                 | status                   | Mogelijk wordt het pand toch niet gesloopt of is het pand al gesloopt. |
+      | Pand             | Verbouwing pand                             | Pand                 | status                   | Mogelijk is de verbouwing al afgerond of wordt de verbouwing niet uitgevoerd. |
+      | Verblijfsobject  | Verblijfsobject gevormd                     | Adresseerbaar object | status                   | Mogelijk is de bouw al gereed of is het verblijfsobject niet gerealiseerd. |
+      | Verblijfsobject  | Niet gerealiseerd verblijfsobject           | Adresseerbaar object | status                   | Mogelijk is het verblijfsobject toch gerealiseerd. |
+      | Verblijfsobject  | Verblijfsobject in gebruik (niet ingemeten) | Adresseerbaar object | status                   | Mogelijk is de geometrie al ingemeten. |
+      | Verblijfsobject  | Verblijfsobject in gebruik                  | Adresseerbaar object | status                   | Mogelijk is het verblijfsobject nog niet in gebruik, is het verblijfsobject al ingetrokken of is er een vergunning tot verbouw verleend. |
+      | Verblijfsobject  | Verbouwing verblijfsobject                  | Adresseerbaar object | status                   | Mogelijk is de verbouwing al afgerond of wordt de verbouwing niet uitgevoerd. |
 
   Scenario: wanneer meerdere gegevens in onderzoek zijn, worden de toelichtingen van beide onderzoeken toegevoegd.
     Gegeven in object nummeraanduiding is gegeven huisnummer in onderzoek
     En in object nummeraanduiding is gegeven huisletter in onderzoek
-    Als de resource adressen wordt opgevraagd
+    Als de afgeleide Adres resource wordt opgevraagd
     Dan bevat het antwoord
       """
           "mogelijkOnjuist": {
@@ -117,7 +117,7 @@ Functionaliteit: Mogelijk onjuist
     Scenario: mogelijkOnjuist wordt ook geleverd wanneer het gegeven geen waarde heeft
       Gegeven in object nummeraanduiding is gegeven huisnummer in onderzoek
       En in object nummeraanduiding heeft huisletter geen waarde of is leeg
-      Als de resource adressen wordt opgevraagd
+      Als de afgeleide Adres resource wordt opgevraagd
       Dan bevat het antwoord geen property huisletter
       En bevat het antwoord
         """
@@ -130,7 +130,7 @@ Functionaliteit: Mogelijk onjuist
         """
     Scenario: mogelijkOnjuist wordt geleverd voor velden die gevraagd zijn met fields
       Gegeven in object nummeraanduiding is gegeven huisnummer in onderzoek
-      Als de resource adressen wordt opgevraagd met fields=postcode,huisnummer
+      Als de afgeleide Adres resource wordt opgevraagd met fields=postcode,huisnummer
       Dan bevat het antwoord property mogelijkOnjuist.huisnummer met de waarde true
       En bevat het antwoord geen property mogelijkOnjuist.postcode
       En bevat het antwoord property postcode met een waarde
@@ -138,14 +138,14 @@ Functionaliteit: Mogelijk onjuist
 
     Scenario: mogelijkOnjuist wordt niet geleverd voor velden die niet gevraagd zijn met fields
       Gegeven in object Woonplaats is gegeven Status woonplaats in onderzoek
-      Als de resource adressen wordt opgevraagd met fields=postcode,huisnummer
+      Als de afgeleide Adres resource wordt opgevraagd met fields=postcode,huisnummer
       Dan bevat het antwoord geen property mogelijkOnjuist
       En bevat het antwoord property postcode met een waarde
       En bevat het antwoord property huisnummer met een waarde
 
     Scenario: mogelijkOnjuist bij objectstatus in onderzoek en gebruik fields
       Gegeven in object nummeraanduiding is gegeven Status nummeraanduiding in onderzoek
-      Als de resource adressen wordt opgevraagd met fields=postcode,huisnummer
+      Als de afgeleide Adres resource wordt opgevraagd met fields=postcode,huisnummer
       Dan bevat het antwoord
         """
             "mogelijkOnjuist": {
@@ -159,7 +159,7 @@ Functionaliteit: Mogelijk onjuist
       Gegeven in object nummeraanduiding is gegeven huisnummer in onderzoek
       En in object nummeraanduiding is gegeven huisletter in onderzoek
       En in object nummeraanduiding is gegeven postcode niet in onderzoek
-      Als de resource adressen wordt opgevraagd met fields=huisnummer,mogelijkOnjuist.huisletter,mogelijkOnjuist.postcode
+      Als de afgeleide Adres resource wordt opgevraagd met fields=huisnummer,mogelijkOnjuist.huisletter,mogelijkOnjuist.postcode
       Dan bevat het antwoord property mogelijkOnjuist.huisnummer met de waarde true
       En bevat het antwoord property mogelijkOnjuist.huisletter met de waarde true
       En bevat het antwoord geen property mogelijkOnjuist.postcode
@@ -170,7 +170,7 @@ Functionaliteit: Mogelijk onjuist
     Scenario: mogelijkOnjuist vragen met fields
       Gegeven in object nummeraanduiding is gegeven huisnummer in onderzoek
       En in object nummeraanduiding is gegeven huisletter in onderzoek
-      Als de resource adressen wordt opgevraagd met fields=mogelijkOnjuist
+      Als de afgeleide Adres resource wordt opgevraagd met fields=mogelijkOnjuist
       Dan bevat het antwoord property mogelijkOnjuist.huisnummer met de waarde true
       En bevat het antwoord property mogelijkOnjuist.huisletter met de waarde true
       En bevat het antwoord geen property mogelijkOnjuist.postcode

--- a/features/mogelijkOnjuist.feature
+++ b/features/mogelijkOnjuist.feature
@@ -1,0 +1,128 @@
+# language: nl
+Functionaliteit: Mogelijk onjuist
+  In de resource wordt aangegeven of bepaalde teruggegeven waarden in de resource mogelijk onjuist zijn. Waarden in de resource zijn mogelijk onjuist wanneer er onderzoek wordt gedaan naar de juistheid van onderliggende gegevens in de registratie.
+
+  Scenario: wanneer de status van een object in onderzoek is, zijn alle daaruit afgeleide properties van de resource mogelijk onjuist
+    Gegeven een resource adressen wordt opgevraagd
+    En in object nummeraanduiding is gegeven Status nummeraanduiding in onderzoek
+    Dan bevat het antwoord
+      """
+          "mogelijkOnjuist": {
+              "korteNaam": true,
+              "straat": true,
+              "huisnummer": true,
+              "huisletter": true,
+              "huisnummertoevoeging": true,
+              "postcode": true,
+              "woonplaats": true,
+              "woonplaatsIdentificatie": true,
+              "nummeraanduidingIdentificatie": true,
+              "openbareRuimteIdentificatie": true,
+              "adresseerbaarObjectIdentificatie": true,
+              "toelichting": [ "Adres bestaat mogelijk niet (meer)." ]
+          }
+      """
+
+  Scenario: wanneer meerdere properties in de resource afgeleid zijn van hetzelfde gegeven in de registratie zijn al deze properties van de resource mogelijk onjuist
+    Gegeven een resource adressen wordt opgevraagd
+    En in object Woonplaats is gegeven Status woonplaats in onderzoek
+    Dan bevat het antwoord
+      """
+          "mogelijkOnjuist": {
+              "woonplaats": true,
+              "woonplaatsIdentificatie": true,
+              "toelichting": [ "Woonplaats bestaat mogelijk niet." ]
+          }
+      """
+
+
+  Abstract Scenario: mogelijkOnjuist wordt gevuld op basis van in onderzoek staan van gegevens in de registratie
+    Gegeven een resource <Resource> wordt opgevraagd
+    En in object <Objecttype> is gegeven <Attribuut in de BAG> in onderzoek
+    Dan bevat het antwoord in property mogelijkOnjuist de property of properties <mogelijkOnjuist property> met de boolean waarde true
+    En bevat het antwoord in property mogelijkOnjuist de property toelichting met een waarde "<toelichting>"
+    En bevat het antwoord in property mogelijkOnjuist geen andere properties dan <mogelijkOnjuist property> en toelichting
+
+    Voorbeelden:
+      | Objecttype       | Attribuut in de BAG                      | Resource              | mogelijkOnjuist property | toelichting |
+      | Woonplaats       | Naam woonplaats                          | adressen              | woonplaats               | Woonplaatsnaam is mogelijk onjuist geschreven. |
+      | Woonplaats       | Status woonplaats                        | adressen              | woonplaats,woonplaatsIdentificatie | Woonplaats bestaat mogelijk niet. |
+      | Woonplaats       | Geometrie                                | adressen              | woonplaats,woonplaatsIdentificatie | Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt. |
+      | Openbare ruimte  | Naam openbare ruimte                     | adressen              | straat,korteNaam         | Straatnaam komt niet overeen met de vermelding in het straatnaambesluit. |
+      | Openbare ruimte  | Status openbare ruimte                   | adressen              | straat,korteNaam,openbareRuimteIdentificatie | Straat bestaat mogelijk niet (meer). |
+      | Openbare ruimte  | Ligt in gerelateerde woonplaats          | adressen              | woonplaats,woonplaatsIdentificatie | Mogelijk verkeerde woonplaats gebruikt. De straat moet verwijzen naar de woonplaats waarin de straat fysiek ligt. |
+      | Nummeraanduiding | Huisnummer                               | adressen              | huisnummer               | Mogelijk is het verkeerde huisnummer geregistreerd. |
+      | Nummeraanduiding | Huisletter                               | adressen              | huisletter               | Mogelijk is ten onrechte een huisletter toegekend, ontbreekt de huisletter ten onrechte, of is een verkeerde huisletter toegekend. |
+      | Nummeraanduiding | Huisnummertoevoeging                     | adressen              | huisnummertoevoeging     | Mogelijk is ten onrechte een huislettertoevoeging toegekend, ontbreekt de huislettertoevoeging ten onrechte, of is een verkeerde huislettertoevoeging toegekend. |
+      | Nummeraanduiding | Postcode                                 | adressen              | postcode                 | Mogelijk is ten onrechte een postcode toegekend, ontbreekt de postcode ten onrechte, of is een verkeerde postcode toegekend. |
+      | Nummeraanduiding | Status nummeraanduiding                  | adressen              | straat,korteNaam,huisnummer,huisletter,huisnummertoevoeging,postcode,woonplaats,nummeraanduidingIdentificatie,woonplaatsIdentificatie,openbareRuimteIdentificatie,adresseerbaarObjectIdentificatie | Adres bestaat mogelijk niet (meer). |
+      | Nummeraanduiding | Ligt in gerelateerde woonplaats          | adressen              | woonplaatsnummeraanduidingIdentificatie | Mogelijk verkeerde woonplaats gebruikt. Het adres moet verwijzen naar de woonplaats waarin het adres fysiek ligt. |
+      | Nummeraanduiding | Ligt aan gerelateerde openbare ruimte    | adressen              | straat,korteNaam,openbareRuimteIdentificatie | Mogelijk verkeerde straat gebruikt. Het adres moet verwijzen naar de straat waaraan het adres ligt. |
+      | Pand             | Geometrie                                | panden                | geometrie                | Mogelijk is de locatie van de contouren onjuist. Mogelijk is de contour onjuist, bijvoorbeeld omdat een uitbouw of een gedeeltelijke sloop niet verwerkt is. |
+      | Pand             | Bouwjaar                                 | panden                | oorspronkelijkBouwjaar   | Bouwjaar is mogelijk onjuist. |
+      | Pand             | Status                                   | panden                | status                   | De meest voor de handliggende mogelijke onjuistheden zijn: Bouwvergunning verleend: mogelijk is de bouw al gestart; mogelijk is de bouw al gereed; mogelijk is het pand niet gerealiseerd. Niet gerealiseerd pand: mogelijk is het pand toch gerealiseerd. Bouw gestart: mogelijk is de bouw al gereed; mogelijk is het pand niet gerealiseerd. Pand in gebruik (niet ingemeten): mogelijk is de geometrie al ingemeten. Pand in gebruik: mogelijk is het pand nog niet in gebruik; mogelijk is het pand al gesloopt; mogelijk is er een vergunning tot verbouw verleend; mogelijk is er een sloopmelding gedaan. Sloopvergunning verleend: Mogelijk wordt het pand toch niet gesloopt; Mogelijk is het pand al gesloopt. |
+      | Verblijfsobject  | Geometrie                                | adresseerbareobjecten | geometrie                | Locatie/contour mogelijk onjuist. |
+      | Standplaats      | Geometrie                                | adresseerbareobjecten | geometrie                | Locatie/contour mogelijk onjuist. |
+      | Ligplaats        | Geometrie                                | adresseerbareobjecten | geometrie                | Locatie/contour mogelijk onjuist. |
+      | Verblijfsobject  | Gebruiksdoel                             | adresseerbareobjecten | gebruiksdoel             | Het gebruiksdoel is mogelijk onjuist. In de BAG wordt het vergunde gebruik geregistreerd. Het gebruiksdoel moet overeenkomen met het gebruik zoals beschreven in de vergunning. |
+      | Verblijfsobject  | Oppervlakte                              | adresseerbareobjecten | oppervlakte              | De oppervlakte is mogelijk onjuist. |
+      | Verblijfsobject  | Status                                   | adresseerbareobjecten | status                   | De meest voor de handliggende mogelijke onjuistheden zijn: Bij verblijfsobject gevormd: mogelijk is de bouw al gereed; mogelijk is het verblijfsobject niet gerealiseerd. Niet gerealiseerd verblijfsobject: mogelijk is het verblijfsobject toch gerealiseerd. Verblijfsobject in gebruik (niet ingemeten): mogelijk is de geometrie al ingemeten. Verblijfsobject in gebruik: mogelijk is het verblijfsobject nog niet in gebruik; mogelijk is het verblijfsobject al ingetrokken; mogelijk is er een vergunning tot verbouw verleend. |
+      | Standplaats      | Status                                   | adresseerbareobjecten | status                   | De standplaats bestaat mogelijk niet (meer). |
+      | Ligplaats        | Status                                   | adresseerbareobjecten | status                   | De ligplaats bestaat mogelijk niet (meer). |
+      | Verblijfsobject  | Maakt onderdeel uit van gerelateerd Pand | adresseerbareobjecten | pandIdentificaties       | Verblijfsobject maakt mogelijk deel uit van een ander pand. |
+      | Verblijfsobject  | Heeft als hoofadres                      | adresseerbareobjecten | hoofdAdresIdentificatie  | AdresseerbaarObject heeft mogelijk een verkeerd adres. Het gerelateerde hoofdadres(ID) mag niet worden gewijzigd want is onlosmakelijk met het adresseerbaar object verbonden. Kan alleen opgelost worden door de gegevens van het adres te veranderen, zodat een ander adres ontstaat. |
+      | Standplaats      | Heeft als hoofdadres                     | adresseerbareobjecten | hoofdAdresIdentificatie  | AdresseerbaarObject heeft mogelijk een verkeerd adres. Het gerelateerde hoofdadres(ID) mag niet worden gewijzigd want is onlosmakelijk met het adresseerbaar object verbonden. Kan alleen opgelost worden door de gegevens van het adres te veranderen, zodat een ander adres ontstaat. |
+      | Ligplaats        | Heeft als hoofdadres                     | adresseerbareobjecten | hoofdAdresIdentificatie  | AdresseerbaarObject heeft mogelijk een verkeerd adres. Het gerelateerde hoofdadres(ID) mag niet worden gewijzigd want is onlosmakelijk met het adresseerbaar object verbonden. Kan alleen opgelost worden door de gegevens van het adres te veranderen, zodat een ander adres ontstaat. |
+      | Verblijfsobject  | Heeft als nevenadres                     | adresseerbareobjecten | nevenAdresIdentificaties | Mogelijk is ten onrechte een nevenadres toegekend of ontbreekt de relatie met een nevenadres. |
+      | Standplaats      | Heeft als nevenadres                     | adresseerbareobjecten | nevenAdresIdentificaties | Mogelijk is ten onrechte een nevenadres toegekend of ontbreekt de relatie met een nevenadres. |
+      | Ligplaats        | Heeft als nevenadres                     | adresseerbareobjecten | nevenAdresIdentificaties | Mogelijk is ten onrechte een nevenadres toegekend of ontbreekt de relatie met een nevenadres. |
+
+  Scenario: wanneer meerdere gegevens in onderzoek zijn, worden de toelichtingen van beide onderzoeken toegevoegd.
+    Gegeven een resource adressen wordt opgevraagd
+    En in object nummeraanduiding is gegeven huisnummer in onderzoek
+    En in object nummeraanduiding is gegeven huisletter in onderzoek
+    Dan bevat het antwoord
+      """
+          "mogelijkOnjuist": {
+              "huisnummer": true,
+              "huisletter": true,
+              "toelichting": [
+                "Mogelijk is het verkeerde huisnummer geregistreerd.",
+                "Mogelijk is ten onrechte een huisletter toegekend, ontbreekt de huisletter ten onrechte, of is een verkeerde huisletter toegekend."
+              ]
+          }
+      """
+
+    Scenario: mogelijkOnjuist wordt ook geleverd wanneer het gegeven geen waarde heeft
+      Gegeven een resource adressen wordt opgevraagd
+      En in object nummeraanduiding is gegeven huisnummer in onderzoek
+      En in object nummeraanduiding heeft huisletter geen waarde of is leeg
+      Dan bevat het antwoord geen property huisletter
+      En bevat het antwoord
+        """
+            "mogelijkOnjuist": {
+                "huisletter": true,
+                "toelichting": [
+                  "Mogelijk is ten onrechte een huisletter toegekend, ontbreekt de huisletter ten onrechte, of is een verkeerde huisletter toegekend."
+                ]
+            }
+        """
+
+    Scenario: mogelijkOnjuist wordt niet geleverd voor velden die niet gevraagd zijn met fields
+      Gegeven een resource adressen wordt opgevraagd met fields=postcode,huisnummer
+      En in object Woonplaats is gegeven Status woonplaats in onderzoek
+      Dan bevat het antwoord geen property mogelijkOnjuist
+      En bevat het antwoord property postcode met een waarde
+      En bevat het antwoord property huisnummer met een waarde
+
+    Scenario: mogelijkOnjuist bij objectstatus in onderzoek en gebruik fields
+      Gegeven een resource adressen wordt opgevraagd met fields=postcode,huisnummer
+      En in object nummeraanduiding is gegeven Status nummeraanduiding in onderzoek
+      Dan bevat het antwoord
+        """
+            "mogelijkOnjuist": {
+                "huisnummer": true,
+                "postcode": true,
+                "toelichting": [ "Adres bestaat mogelijk niet (meer)." ]
+            }
+        """


### PR DESCRIPTION
n.a.v. #120 voorstel voor het vullen van mogelijkOnjuist:
- alleen properties zoals die ook in de resource zitten (geen toevoegingen voor oorzaak, aard van onderzoek)
- opnemen property "toelichting" waarin uitleg staat over de aard van het mogelijk onjuist zijn

Het onderscheid in de reden voor twijfel (bijvoorbeeld bij een woonplaats gaat het om de naam van de woonplaats, of over welke woonplaats het adres ligt) is namelijk alleen belangrijk voor een natuurlijk persoon om te lezen en interpreteren. Dit onderscheid hoeft niet machineleesbaar te zijn. Voor de machine (software) hoeft alleen geconstateerd te worden dat het gegeven onderzocht wordt. De interpretatie wordt gemaakt door de eindgebruiker.

Voordelen:
1. eenvoudige structuur van mogelijkOnjuist die 1-op-1 aansluit bij de resource
2. mogelijkheid om toelichting te leveren, zodat minder eigen BAG-kennis of interpretatie nodig is.