### PR TITLE
Consistente set van examples doorgevoerd

### DIFF
--- a/api-specificatie/openapi.yaml
+++ b/api-specificatie/openapi.yaml
@@ -543,6 +543,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/adresseerbaarobjectidentificatie-query'
         - $ref: '#/components/parameters/locatie-query'
+        - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/expand'
         - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields'
         - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/acceptCrs'
         - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/contentCrs'
@@ -630,8 +631,8 @@ components:
         items:
           type: number
         example:
-        - 196733.510
-        - 439931.890
+        - 194602.722
+        - 464154.308
 
     nummeraanduidingidentificatie-query:
       description: "Identificatie van een nummeraanduiding uit de BAG. Deze is 16 cijfers lang."
@@ -641,7 +642,7 @@ components:
       schema:
         type: string
         pattern: '^[0-9]{16}$'
-        example: '0226200000038923'
+        example: '1234200000000001'
 
     pandidentificatie-query:
       description: "Identificatie van een pand uit de BAG. Deze is 16 cijfers lang."
@@ -651,7 +652,7 @@ components:
       schema:
         type: string
         pattern: '^[0-9]{16}$'
-        example: '0226100000008856'
+        example: '1234100000000001'
 
     adresseerbaarobjectidentificatie-query:
       description: "De identificatie van een adresserbaar object uit de BAG. Dit kan een verblijfsobject, een standplaats of een ligplaats zijn."
@@ -661,7 +662,7 @@ components:
       schema:
         type: string
         pattern: '^[0-9]{16}$'
-        example: '0226010000038820'
+        example: '1234010000000001'
 
     # Opsomming van path parameters - /{...} - specificatie bij operation zelf.
     nummeraanduidingidentificatie:
@@ -672,7 +673,7 @@ components:
       schema:
         type: string
         pattern: '^[0-9]{16}$'
-        example: '0226200000038923'
+        example: '1234200000000001'
 
     adresseerbaarobjectidentificatie:
       description: "De identificatie van een adresserbaar object uit de BAG. Dit kan een verblijfsobject, een standplaats of een ligplaats zijn."
@@ -682,7 +683,7 @@ components:
       schema:
         type: string
         pattern: '^[0-9]{16}$'
-        example: '0226010000038820'
+        example: '1234010000000001'
 
     pandidentificatie:
       description: "Identificatie van een pand uit de BAG. Deze is 16 cijfers lang."
@@ -692,7 +693,7 @@ components:
       schema:
         type: string
         pattern: '^[0-9]{16}$'
-        example: '0226100000008856'
+        example: '1234100000000001'
 
     woonplaatsidentificatie:
       description: "Identificatie van een object uit de BAG. Deze is 4 lang bij een woonplaats en 16 lang bij de andere objecten."
@@ -702,8 +703,8 @@ components:
       schema:
         description: "Deze wordt gebruikt in de operation, bv. /woonplaatsen/0123. Waarde: 0001-9999."
         type: string
-        pattern: '^[0-9]{3}[1-9]|[0-9]{2}[1-9][0-9]|[0-9][1-9][0-9]{2}|[1-9][0-9]{3}$'
-        example: '2096'
+        pattern: '[0-9]{3}[1-9]|[0-9]{2}[1-9][0-9]|[0-9][1-9][0-9]{2}|[1-9][0-9]{3}'
+        example: '3560'
 
     openbareruimteidentificatie:
       description: "Identificatie van een object uit de BAG. Deze is 4 lang bij een woonplaats en 16 lang bij de andere objecten."
@@ -713,7 +714,7 @@ components:
       schema:
         type: string
         pattern: '^[0-9]{16}$'
-        example: '0226300000136166'
+        example: '0518300000000001'
 
   schemas:
 

--- a/api-specificatie/openapi.yaml
+++ b/api-specificatie/openapi.yaml
@@ -634,7 +634,6 @@ components:
         - 194602.722
         - 464154.308
 
-
     nummeraanduidingidentificatie-query:
       description: "Identificatie van een nummeraanduiding uit de BAG. Deze is 16 cijfers lang."
       name: nummeraanduidingidentificatie
@@ -767,7 +766,7 @@ components:
         huisnummer:
           description: "Een nummer dat door de gemeente aan een adresseerbaar object is gegeven."
           type: integer
-          example: 12
+          example: 1
         huisletter:
           description: "Een toevoeging aan een huisnummer in de vorm van een letter of een cijfer die door de gemeente aan een adresseerbaar object is gegeven."
           type: string
@@ -779,12 +778,12 @@ components:
         postcode:
           description: "De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort."
           type: string
-          example: '7500AA'
+          example: '6922KZ'
         woonplaats:
           description: "Een woonplaats is een gedeelte van het grondgebied van de gemeente met een naam."
           title: woonplaats naam
           type: string
-          example: 'Apeldoorn'
+          example: 'Duiven'
     AdresUitgebreid:
       allOf:
       - $ref: "#/components/schemas/Adres"
@@ -798,22 +797,22 @@ components:
           nummeraanduidingIdentificatie:
             type: string
             description: "Fungeert ook als identificatie van het adres."
-            example: '1234200000000001'
+            example: '0226200000038923'
           openbareRuimteIdentificatie:
             type: string
-            example: '0518300000000001'
+            example: '0226300000136166'
           woonplaatsIdentificatie:
             type: string
-            example: '3560'
+            example: '2096'
           adresseerbaarObjectIdentificatie:
             type: string
-            example: '1234010000000001'
+            example: '0226010000038820'
           pandIdentificaties:
             description: "Identificatie(s) van het pand of de panden waar het verblijfsobject deel van is."
             type: array
             items:
               type: string
-              example: '1234100000000001'
+              example: '0226100000008856'
           indicatieNevenadres:
             description: "Indicatie dat dit adres een nevenadres is van een adresseerbaar object. Het adres is een hoofdadres als deze indicatie niet wordt meegeleverd."
             type: boolean
@@ -913,18 +912,18 @@ components:
         identificatie:
           description: "Dit is de identificatie van een ligplaats, standplaats of verblijfsobject."
           type: string
-          example: "01230167890123456"
+          example: "0226010000038820"
         type:
           $ref: '#/components/schemas/TypeAdresseerbaarObject_enum'
           title: adresseerbaarObjectType
         documentdatum:
           description: "De vaststellingsdatum van het brondocument dat de basis is voor opname, wijziging of een verwijdering van een object."
-          example: "2019-08-14"
+          example: "2019-11-22"
           format: date
           type: string
         documentnummer:
           description: "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van een woonplaats heeft plaatsgevonden, binnen een gemeente. Alle karakters uit de MES-1 karakterset zijn toegstaan."
-          example: AV-2019-08-19-00
+          example: "19SZ2048"
           type: string
         gebruiksdoelen:
           items:
@@ -939,7 +938,7 @@ components:
           description: "Identificatie(s) van het pand of de panden waar het verblijfsobject deel van is."
           items:
             type: string
-            example: '1234100000000001'
+            example: '0226100000008856'
           type: array
         nummeraanduidingIdentificaties:
           description: "Identificatie(s) van de hoofd- en nevenadressen van de standplaats, ligplaats of verblijfsobject."
@@ -1059,7 +1058,6 @@ components:
         - 'winkelfunctie'
         - 'overige gebruiksfunctie'
 
-
     OpenbareRuimte:
       type: object
       description: "Een buitenruimte met een naam die binnen één woonplaats ligt, bijvoorbeeld een straat of een plein."
@@ -1087,15 +1085,15 @@ components:
           description: "De vaststellingsdatum van het brondocument dat de basis is voor opname, wijziging of een verwijdering van een object."
           type: string
           format: date
-          example: '2019-08-14'
+          example: '2010-02-09'
         documentnummer:
           description: "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van een woonplaats heeft plaatsgevonden, binnen een gemeente. Alle karakters uit de MES-1 karakterset zijn toegstaan."
           type: string
-          example: 'AV-2019-08-19-00'
+          example: 'BAG-21'
         woonplaatsIdentificatie:
           type: string
           description: "Een openbare ruimte ligt in een woonplaats."
-          example: '3560'
+          example: '2096'
         mogelijkOnjuist:
           $ref: '#/components/schemas/OpenbareRuimteMogelijkOnjuist'
     OpenbareRuimteMogelijkOnjuist:
@@ -1142,7 +1140,7 @@ components:
         huisnummer:
           description: "Nummer dat door de gemeente aan een adresseerbaar object is gegeven."
           type: integer
-          example: 12
+          example: 1
         huisletter:
           description: "Toevoeging aan een huisnummer in de vorm van een letter of een cijfer die door de gemeente aan een adresseerbaar object is gegeven."
           type: string
@@ -1154,7 +1152,7 @@ components:
         postcode:
           description: "Door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort."
           type: string
-          example: '7500AA'
+          example: '6922KZ'
         status:
           $ref: '#/components/schemas/StatusNaamgeving_enum'
         geconstateerd:
@@ -1164,19 +1162,19 @@ components:
           description: "De vaststellingsdatum van het brondocument dat de basis is voor opname, wijziging of een verwijdering van een object."
           type: string
           format: date
-          example: '2019-08-14'
+          example: '2019-11-25'
         documentnummer:
           description: "Identificatie van het brondocument dat ten grondslag ligt aan de opname, mutatie of een verwijdering van gegevens."
           type: string
-          example: 'AV-2019-08-19-00'
+          example: 'Duiven 25112019'
         woonplaatsIdentificatie:
           type: string
           description: "Een nummeraanduiding ligt in een woonplaats."
-          example: '3560'
+          example: '2096'
         openbareRuimteIdentificatie:
           type: string
           description: "Een nummeraanduiding ligt aan een openbare ruimte."
-          example: '0518300000000001'
+          example: '0226300000136166'
         mogelijkOnjuist:
           $ref: '#/components/schemas/NummeraanduidingMogelijkOnjuist'
     NummeraanduidingIdentificatiesArray:
@@ -1184,7 +1182,7 @@ components:
       properties:
         nummeraanduidingIdentificatie:
           type: string
-          example: '1234200000000001'
+          example: '0226200000038923'
         indicatieNevenadres:
           type: boolean
     NummeraanduidingMogelijkOnjuist:
@@ -1241,7 +1239,7 @@ components:
         naam:
           description: "De naam van de woonplaats."
           type: string
-          example: 'Apeldoorn'
+          example: 'Duiven'
         status:
           $ref: '#/components/schemas/StatusWoonplaats_enum'
           description: "De fase van de levenscyclus van een woonplaats, waarin de betreffende woonplaats zich bevindt."
@@ -1252,11 +1250,11 @@ components:
           description: "De vaststellingsdatum van het brondocument dat de basis is voor opname, wijziging of een verwijdering van een object."
           type: string
           format: date
-          example: '2019-08-14'
+          example: '2009-02-09'
         documentnummer:
           description: "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van een woonplaats heeft plaatsgevonden, binnen een gemeente. Alle karakters uit de MES-1 karakterset zijn toegstaan."
           type: string
-          example: 'AV-2019-08-19-00'
+          example: '09.0898'
         mogelijkOnjuist:
           $ref: "#/components/schemas/WoonplaatsMogelijkOnjuist"
     WoonplaatsMogelijkOnjuist:
@@ -1311,7 +1309,7 @@ components:
         oorspronkelijkBouwjaar:
           description: "Het jaar waarin een pand oorspronkelijk als bouwkundig gereed is wordt opgeleverd. Door de gemeente wordt een inschatting gemaakt van het bouwjaar, en aangepast als het pand wordt opgeleverd. Wijzigingen aan een pand na oplevering leiden niet tot wijziging van het bouwjaar."
           type: integer
-          example: 1972
+          example: 1991
         status:
           $ref: '#/components/schemas/StatusPand_enum'
           description: "Een codering van de verschillende waarden die de status van een pand kan aannemen."
@@ -1322,16 +1320,16 @@ components:
           description: "De vaststellingsdatum van het brondocument dat de basis is voor opname, wijziging of een verwijdering van een object."
           type: string
           format: date
-          example: '2019-08-14'
+          example: '2009-05-12'
         documentnummer:
           description: "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van een woonplaats heeft plaatsgevonden, binnen een gemeente. Alle karakters uit de MES-1 karakterset zijn toegstaan."
           type: string
-          example: 'AV-2019-08-19-00'
+          example: '09.BW.0273'
         adresseerbaarObjectIdentificaties:
           type: array
           items:
             type: string
-            example: '1234010000000001'
+            example: '0226010000038820'
         nummeraanduidingIdentificaties:
           description: "Identificatie(s) van de hoofd- en nevenadressen van het pand."
           items:

--- a/api-specificatie/openapi.yaml
+++ b/api-specificatie/openapi.yaml
@@ -543,7 +543,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/adresseerbaarobjectidentificatie-query'
         - $ref: '#/components/parameters/locatie-query'
-        - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/expand'
         - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields'
         - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/acceptCrs'
         - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/contentCrs'
@@ -631,8 +630,8 @@ components:
         items:
           type: number
         example:
-        - 194602.722
-        - 464154.308
+        - 196733.510
+        - 439931.890
 
     nummeraanduidingidentificatie-query:
       description: "Identificatie van een nummeraanduiding uit de BAG. Deze is 16 cijfers lang."
@@ -642,7 +641,7 @@ components:
       schema:
         type: string
         pattern: '^[0-9]{16}$'
-        example: '1234200000000001'
+        example: '0226200000038923'
 
     pandidentificatie-query:
       description: "Identificatie van een pand uit de BAG. Deze is 16 cijfers lang."
@@ -652,7 +651,7 @@ components:
       schema:
         type: string
         pattern: '^[0-9]{16}$'
-        example: '1234100000000001'
+        example: '0226100000008856'
 
     adresseerbaarobjectidentificatie-query:
       description: "De identificatie van een adresserbaar object uit de BAG. Dit kan een verblijfsobject, een standplaats of een ligplaats zijn."
@@ -662,7 +661,7 @@ components:
       schema:
         type: string
         pattern: '^[0-9]{16}$'
-        example: '1234010000000001'
+        example: '0226010000038820'
 
     # Opsomming van path parameters - /{...} - specificatie bij operation zelf.
     nummeraanduidingidentificatie:
@@ -673,7 +672,7 @@ components:
       schema:
         type: string
         pattern: '^[0-9]{16}$'
-        example: '1234200000000001'
+        example: '0226200000038923'
 
     adresseerbaarobjectidentificatie:
       description: "De identificatie van een adresserbaar object uit de BAG. Dit kan een verblijfsobject, een standplaats of een ligplaats zijn."
@@ -683,7 +682,7 @@ components:
       schema:
         type: string
         pattern: '^[0-9]{16}$'
-        example: '1234010000000001'
+        example: '0226010000038820'
 
     pandidentificatie:
       description: "Identificatie van een pand uit de BAG. Deze is 16 cijfers lang."
@@ -693,7 +692,7 @@ components:
       schema:
         type: string
         pattern: '^[0-9]{16}$'
-        example: '1234100000000001'
+        example: '0226100000008856'
 
     woonplaatsidentificatie:
       description: "Identificatie van een object uit de BAG. Deze is 4 lang bij een woonplaats en 16 lang bij de andere objecten."
@@ -703,8 +702,8 @@ components:
       schema:
         description: "Deze wordt gebruikt in de operation, bv. /woonplaatsen/0123. Waarde: 0001-9999."
         type: string
-        pattern: '[0-9]{3}[1-9]|[0-9]{2}[1-9][0-9]|[0-9][1-9][0-9]{2}|[1-9][0-9]{3}'
-        example: '3560'
+        pattern: '^[0-9]{3}[1-9]|[0-9]{2}[1-9][0-9]|[0-9][1-9][0-9]{2}|[1-9][0-9]{3}$'
+        example: '2096'
 
     openbareruimteidentificatie:
       description: "Identificatie van een object uit de BAG. Deze is 4 lang bij een woonplaats en 16 lang bij de andere objecten."
@@ -714,7 +713,7 @@ components:
       schema:
         type: string
         pattern: '^[0-9]{16}$'
-        example: '0518300000000001'
+        example: '0226300000136166'
 
   schemas:
 


### PR DESCRIPTION
Deze wijziging bevat een consistente set van examples in de openapi.yaml. Er is niets gewijzigd aan de structuur van de specificatie en de wijziging zal geen impact hebben op gegenereerde code, wel op de geresolvede yaml.
Implementeert: #226.