### PR TITLE
correctie mogelijkOnjuist scenario

### DIFF
--- a/features/mogelijkOnjuist.feature
+++ b/features/mogelijkOnjuist.feature
@@ -176,6 +176,8 @@ Functionaliteit: Mogelijk onjuist
       Gegeven in object nummeraanduiding is gegeven huisnummer in onderzoek
       En in object nummeraanduiding is gegeven huisletter in onderzoek
       En in object nummeraanduiding is gegeven postcode niet in onderzoek
+      En hebben gegevens postcode en huisnummer een waarde
+      En hebben gegevens huisletter en huisnummertoevoeging geen waarde
       Als de afgeleide Adres resource wordt opgevraagd met fields=huisnummer,mogelijkOnjuist.huisletter,mogelijkOnjuist.postcode
       Dan bevat het antwoord property mogelijkOnjuist.huisnummer met de waarde true
       En bevat het antwoord property mogelijkOnjuist.huisletter met de waarde true

--- a/features/mogelijkOnjuist.feature
+++ b/features/mogelijkOnjuist.feature
@@ -180,7 +180,7 @@ Functionaliteit: Mogelijk onjuist
       Dan bevat het antwoord property mogelijkOnjuist.huisnummer met de waarde true
       En bevat het antwoord property mogelijkOnjuist.huisletter met de waarde true
       En bevat het antwoord geen property mogelijkOnjuist.postcode
-      En bevat het antwoord property postcode met een waarde
+      En bevat het antwoord geen property postcode
       En bevat het antwoord property huisnummer met een waarde
       En bevat het antwoord geen property huisletter
 


### PR DESCRIPTION
Scenario "mogelijkOnjuist properties vragen met fields" bevatte een fout in de verwachting: postcode is niet gevraagd en moet dus ook niet in het antwoord zitten