### PR TITLE
Verwijderen zoeken van panden op nummeraanduidingIdentificatie - plus enkele kleine correcties

### DIFF
--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -1,0 +1,4065 @@
+{
+  "openapi" : "3.0.0",
+  "info" : {
+    "title" : "Huidige bevragingen API",
+    "description" : "Deze API levert actuele gegevens over adressen, adresseerbaar objecten en panden. Actueel betekent in deze API `zonder eindstatus`. De bron voor deze API is de basisregistratie adressen en gebouwen (BAG).",
+    "termsOfService" : "https://zakelijk.kadaster.nl/algemene-voorwaarden",
+    "contact" : {
+      "name" : "Kadaster - Beheerder Landelijke Voorziening BAG",
+      "url" : "https://zakelijk.kadaster.nl/bag",
+      "email" : "bag@kadaster.nl"
+    },
+    "license" : {
+      "name" : "European Union Public License, version 1.2 (EUPL-1.2)",
+      "url" : "https://eupl.eu/1.2/nl/"
+    },
+    "version" : "1.0.0"
+  },
+  "servers" : [ {
+    "url" : "https://api.bag.acceptatie.kadaster.nl/esd/huidigebevragingen/v1",
+    "description" : "LVBAG - ACCEPTATIE"
+  }, {
+    "url" : "https://api.bag.kadaster.nl/esd/huidigebevragingen/v1",
+    "description" : "LVBAG - PRODUCTIE"
+  } ],
+  "security" : [ {
+    "apiKeyBAG" : [ ]
+  } ],
+  "paths" : {
+    "/adressen/zoek" : {
+      "get" : {
+        "tags" : [ "Adres" ],
+        "summary" : "\"fuzzy\" zoeken van adressen",
+        "description" : "Free query zoeken van adressen met postcode, woonplaats, straatnaam, huisnummer, huisletter, huisnummertoevoeging. Delen van de adressen in het antwoord matchen exact met jouw invoer. Je vindt een adres door de zoekresultaatidentificatie uit het antwoord te gebruiken in get/adressen",
+        "operationId" : "zoek",
+        "parameters" : [ {
+          "name" : "zoek",
+          "in" : "query",
+          "description" : "Zoekterm op postcode, woonplaats, straatnaam, huisnummer, huisletter, huisnummertoevoeging",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Pagina nummer",
+          "required" : false,
+          "schema" : {
+            "minimum" : 1,
+            "type" : "integer",
+            "default" : 1
+          }
+        }, {
+          "name" : "pageSize",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "maximum" : 100,
+            "minimum" : 1,
+            "type" : "integer",
+            "default" : 20
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Geslaagd",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ZoekResultaatHalCollectie"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "apiKeyBAG" : [ ]
+        } ]
+      }
+    },
+    "/adressen" : {
+      "get" : {
+        "tags" : [ "Adres" ],
+        "summary" : "vindt adressen",
+        "description" : "Vind een actueel adres met de identificatie van het zoekresultaat uit de operatie get /adressen/zoek, de pandidentificatie of de adresseerbaarobjectidentificatie. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature). Gebruik de expand parameter als je het antwoord wil uitbreiden met (delen van) de gerelateerde resources nummeraanduiding, woonplaats en openbare ruimte, zie [functionele specificaties expand-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+        "operationId" : "raadpleegAdressen",
+        "parameters" : [ {
+          "name" : "pandIdentificatie",
+          "in" : "query",
+          "description" : "Identificatie van een pand uit de BAG. Deze is 16 cijfers lang.",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "pattern" : "^[0-9]{16}$",
+            "type" : "string",
+            "example" : "0226100000008856"
+          }
+        }, {
+          "name" : "adresseerbaarObjectIdentificatie",
+          "in" : "query",
+          "description" : "De identificatie van een adresserbaar object uit de BAG. Dit kan een verblijfsobject, een standplaats of een ligplaats zijn.",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "pattern" : "^[0-9]{16}$",
+            "type" : "string",
+            "example" : "0226010000038820"
+          }
+        }, {
+          "name" : "zoekresultaatIdentificatie",
+          "in" : "query",
+          "description" : "De identificatie van een zoekresultaat van het endpoint get /adressen/zoek",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "expand",
+          "in" : "query",
+          "description" : "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. In de definitie van het antwoord kun je bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Pagina nummer",
+          "required" : false,
+          "schema" : {
+            "minimum" : 1,
+            "type" : "integer",
+            "default" : 1
+          }
+        }, {
+          "name" : "pageSize",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "maximum" : 100,
+            "minimum" : 1,
+            "type" : "integer",
+            "default" : 20
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Geslaagd",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AdresHalCollectie"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "apiKeyBAG" : [ ]
+        } ]
+      }
+    },
+    "/adressen/{nummeraanduidingidentificatie}" : {
+      "get" : {
+        "tags" : [ "Adres" ],
+        "summary" : "levert een adres",
+        "description" : "Raadpleeg een actueel adres met de nummeraanduiding identificatie. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature). Gebruik de expand parameter als je het antwoord wil uitbreiden met (delen van) de gerelateerde resources nummeraanduiding, woonplaats en openbare ruimte, zie [functionele specificaties expand-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+        "operationId" : "raadpleegAdresMetNumId",
+        "parameters" : [ {
+          "name" : "nummeraanduidingidentificatie",
+          "in" : "path",
+          "description" : "Identificatie van een nummeraanduiding uit de BAG. Deze is 16 cijfers lang.",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "pattern" : "^[0-9]{16}$",
+            "type" : "string",
+            "example" : "0226200000038923"
+          }
+        }, {
+          "name" : "expand",
+          "in" : "query",
+          "description" : "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. In de definitie van het antwoord kun je bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Geslaagd",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AdresHal"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found",
+                  "title" : "Opgevraagde resource bestaat niet.",
+                  "status" : 404,
+                  "detail" : "The server has not found anything matching the Request-URI.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notFound"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "apiKeyBAG" : [ ]
+        } ]
+      }
+    },
+    "/adresseerbareobjecten/{adresseerbaarobjectidentificatie}" : {
+      "get" : {
+        "tags" : [ "Adresseerbaar object" ],
+        "summary" : "levert een verblijfsobject, standplaats of ligplaats",
+        "description" : "Raadpleeg een actueel adresseerbaar object met de identificatie. Dit is de identificatie van een verblijfsobject, ligplaats of standplaats. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature). Gebruik de expand parameter als je het antwoord wil uitbreiden met (delen van) de gerelateerde resources adres en pand, zie [functionele specificaties expand-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+        "operationId" : "raadpleegAdresseerbaarobject",
+        "parameters" : [ {
+          "name" : "adresseerbaarobjectidentificatie",
+          "in" : "path",
+          "description" : "De identificatie van een adresserbaar object uit de BAG. Dit kan een verblijfsobject, een standplaats of een ligplaats zijn.",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "pattern" : "^[0-9]{16}$",
+            "type" : "string",
+            "example" : "0226010000038820"
+          }
+        }, {
+          "name" : "expand",
+          "in" : "query",
+          "description" : "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. In de definitie van het antwoord kun je bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "Accept-Crs",
+          "in" : "header",
+          "description" : "Gewenste CRS van de coördinaten in de response.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "description" : "CRS van de coördinaten in de response. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel.",
+            "enum" : [ "epsg:28992" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Geslaagd",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              },
+              "Content-Crs" : {
+                "$ref" : "#/components/headers/contentCrs"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AdresseerbaarObjectHal"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found",
+                  "title" : "Opgevraagde resource bestaat niet.",
+                  "status" : 404,
+                  "detail" : "The server has not found anything matching the Request-URI.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notFound"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "412" : {
+            "description" : "Precondition failed",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.13 412 Precondition Failed",
+                  "title" : "Precondition Failed",
+                  "status" : 412,
+                  "detail" : "The precondition given in one or more of the request-header fields evaluated to false when it was tested on the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "preconditionFailed"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "apiKeyBAG" : [ ]
+        } ]
+      }
+    },
+    "/adresseerbareobjecten" : {
+      "get" : {
+        "tags" : [ "Adresseerbaar object" ],
+        "summary" : "vindt verblijfsobjecten, ligplaatsen, standplaatsen",
+        "description" : "Zoek actuele adresseerbaar objecten (verblijfsobjecten, standplaatsen of ligplaatsen) met een nummeraanduiding identificatie of pand identificatie. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature). Gebruik de expand parameter als je het antwoord wil uitbreiden met (delen van) de gerelateerde resources adres en pand, zie [functionele specificaties expand-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+        "operationId" : "raadpleegAdresseerbareobjecten",
+        "parameters" : [ {
+          "name" : "nummeraanduidingIdentificatie",
+          "in" : "query",
+          "description" : "Identificatie van een nummeraanduiding uit de BAG. Deze is 16 cijfers lang.",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "pattern" : "^[0-9]{16}$",
+            "type" : "string",
+            "example" : "0226200000038923"
+          }
+        }, {
+          "name" : "pandIdentificatie",
+          "in" : "query",
+          "description" : "Identificatie van een pand uit de BAG. Deze is 16 cijfers lang.",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "pattern" : "^[0-9]{16}$",
+            "type" : "string",
+            "example" : "0226100000008856"
+          }
+        }, {
+          "name" : "expand",
+          "in" : "query",
+          "description" : "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. In de definitie van het antwoord kun je bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "Accept-Crs",
+          "in" : "header",
+          "description" : "Gewenste CRS van de coördinaten in de response.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "description" : "CRS van de coördinaten in de response. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel.",
+            "enum" : [ "epsg:28992" ]
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Pagina nummer",
+          "required" : false,
+          "schema" : {
+            "minimum" : 1,
+            "type" : "integer",
+            "default" : 1
+          }
+        }, {
+          "name" : "pageSize",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "maximum" : 100,
+            "minimum" : 1,
+            "type" : "integer",
+            "default" : 20
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Geslaagd",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              },
+              "Content-Crs" : {
+                "$ref" : "#/components/headers/contentCrs"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AdresseerbaarobjectHalCollectie"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "412" : {
+            "description" : "Precondition failed",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.13 412 Precondition Failed",
+                  "title" : "Precondition Failed",
+                  "status" : 412,
+                  "detail" : "The precondition given in one or more of the request-header fields evaluated to false when it was tested on the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "preconditionFailed"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "apiKeyBAG" : [ ]
+        } ]
+      }
+    },
+    "/woonplaatsen/{woonplaatsidentificatie}" : {
+      "get" : {
+        "tags" : [ "Adres" ],
+        "summary" : "levert BAG details van een woonplaats",
+        "description" : "Raadpleeg een actuele woonplaats met de identificatie. Een woonplaats is een gedeelte van het grondgebied van de gemeente met een naam. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature). Gebruik de expand parameter als je het antwoord wil uitbreiden met de gerelateerde resource geometrie, zie [functionele specificaties expand-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+        "operationId" : "raadpleegWoonplaats",
+        "parameters" : [ {
+          "name" : "woonplaatsidentificatie",
+          "in" : "path",
+          "description" : "Identificatie van een object uit de BAG. Deze is 4 lang bij een woonplaats en 16 lang bij de andere objecten.",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "pattern" : "^[0-9]{3}[1-9]|[0-9]{2}[1-9][0-9]|[0-9][1-9][0-9]{2}|[1-9][0-9]{3}$",
+            "type" : "string",
+            "description" : "Deze wordt gebruikt in de operation, bv. /woonplaatsen/0123. Waarde: 0001-9999.",
+            "example" : "2096"
+          }
+        }, {
+          "name" : "expand",
+          "in" : "query",
+          "description" : "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. In de definitie van het antwoord kun je bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "Accept-Crs",
+          "in" : "header",
+          "description" : "Gewenste CRS van de coördinaten in de response.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "description" : "CRS van de coördinaten in de response. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel.",
+            "enum" : [ "epsg:28992" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Geslaagd",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              },
+              "Content-Crs" : {
+                "$ref" : "#/components/headers/contentCrs"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/WoonplaatsHal"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found",
+                  "title" : "Opgevraagde resource bestaat niet.",
+                  "status" : 404,
+                  "detail" : "The server has not found anything matching the Request-URI.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notFound"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "412" : {
+            "description" : "Precondition failed",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.13 412 Precondition Failed",
+                  "title" : "Precondition Failed",
+                  "status" : 412,
+                  "detail" : "The precondition given in one or more of the request-header fields evaluated to false when it was tested on the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "preconditionFailed"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "apiKeyBAG" : [ ]
+        } ]
+      }
+    },
+    "/openbareruimten/{openbareruimteidentificatie}" : {
+      "get" : {
+        "tags" : [ "Adres" ],
+        "summary" : "levert BAG detals van een openbare ruimte",
+        "description" : "Raadpleeg een actuele openbare ruimte met de identificatie. Een openbare ruimte is een buitenruimte met een naam die binnen één woonplaats ligt, bijvoorbeeld een straat of een plein. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+        "operationId" : "raadpleegOpenbareRuimte",
+        "parameters" : [ {
+          "name" : "openbareruimteidentificatie",
+          "in" : "path",
+          "description" : "Identificatie van een object uit de BAG. Deze is 4 lang bij een woonplaats en 16 lang bij de andere objecten.",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "pattern" : "^[0-9]{16}$",
+            "type" : "string",
+            "example" : "0226300000136166"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Geslaagd",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OpenbareRuimteHalBasis"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found",
+                  "title" : "Opgevraagde resource bestaat niet.",
+                  "status" : 404,
+                  "detail" : "The server has not found anything matching the Request-URI.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notFound"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "apiKeyBAG" : [ ]
+        } ]
+      }
+    },
+    "/nummeraanduidingen/{nummeraanduidingidentificatie}" : {
+      "get" : {
+        "tags" : [ "Adres" ],
+        "summary" : "levert BAG details van een nummeraanduiding",
+        "description" : "Raadpleeg een actuele nummeraanduiding met de identificatie. Een nummeraanduiding is een postcode, huisnummer met evt een huisletter en huisnummertoevoeging die hoort bij een verblijfsobject, een standplaats of een ligplaats. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+        "operationId" : "raadpleegNummeraanduiding",
+        "parameters" : [ {
+          "name" : "nummeraanduidingidentificatie",
+          "in" : "path",
+          "description" : "Identificatie van een nummeraanduiding uit de BAG. Deze is 16 cijfers lang.",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "pattern" : "^[0-9]{16}$",
+            "type" : "string",
+            "example" : "0226200000038923"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Geslaagd",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/NummeraanduidingHalBasis"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found",
+                  "title" : "Opgevraagde resource bestaat niet.",
+                  "status" : 404,
+                  "detail" : "The server has not found anything matching the Request-URI.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notFound"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "apiKeyBAG" : [ ]
+        } ]
+      }
+    },
+    "/panden/{pandidentificatie}" : {
+      "get" : {
+        "tags" : [ "Pand" ],
+        "summary" : "levert een pand",
+        "description" : "Raadpleeg een actueel pand met de identificatie. Een pand is een bouwkundige, constructief zelfstandige eenheid die direct en duurzaam met de aarde is verbonden en betreedbaar en afsluitbaar is. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature).",
+        "operationId" : "raadpleegPand",
+        "parameters" : [ {
+          "name" : "pandidentificatie",
+          "in" : "path",
+          "description" : "Identificatie van een pand uit de BAG. Deze is 16 cijfers lang.",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "pattern" : "^[0-9]{16}$",
+            "type" : "string",
+            "example" : "0226100000008856"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "Accept-Crs",
+          "in" : "header",
+          "description" : "Gewenste CRS van de coördinaten in de response.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "description" : "CRS van de coördinaten in de response. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel.",
+            "enum" : [ "epsg:28992" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Geslaagd",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              },
+              "Content-Crs" : {
+                "$ref" : "#/components/headers/contentCrs"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PandHalBasis"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found",
+                  "title" : "Opgevraagde resource bestaat niet.",
+                  "status" : 404,
+                  "detail" : "The server has not found anything matching the Request-URI.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notFound"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "412" : {
+            "description" : "Precondition failed",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.13 412 Precondition Failed",
+                  "title" : "Precondition Failed",
+                  "status" : 412,
+                  "detail" : "The precondition given in one or more of the request-header fields evaluated to false when it was tested on the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "preconditionFailed"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "apiKeyBAG" : [ ]
+        } ]
+      }
+    },
+    "/panden" : {
+      "get" : {
+        "tags" : [ "Pand" ],
+        "summary" : "vindt panden",
+        "description" : "Zoek actuele panden met de identificatie van een adresseerbaar object of een locatie. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature).",
+        "operationId" : "raadpleegPanden",
+        "parameters" : [ {
+          "name" : "adresseerbaarObjectIdentificatie",
+          "in" : "query",
+          "description" : "De identificatie van een adresserbaar object uit de BAG. Dit kan een verblijfsobject, een standplaats of een ligplaats zijn.",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "pattern" : "^[0-9]{16}$",
+            "type" : "string",
+            "example" : "0226010000038820"
+          }
+        }, {
+          "name" : "locatie",
+          "in" : "query",
+          "description" : "Coordinaten van een locatie die als query-parmeter gebruikt wordt om een object te zoeken. Let op, explode is false dus het formaat is ?locatie=194602.722,464154.308",
+          "required" : false,
+          "style" : "form",
+          "explode" : false,
+          "schema" : {
+            "maxItems" : 2,
+            "minItems" : 2,
+            "type" : "array",
+            "example" : [ 196733.51, 439931.89 ],
+            "items" : {
+              "type" : "number"
+            }
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "Accept-Crs",
+          "in" : "header",
+          "description" : "Gewenste CRS van de coördinaten in de response.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "description" : "CRS van de coördinaten in de response. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel.",
+            "enum" : [ "epsg:28992" ]
+          }
+        }, {
+          "name" : "Content-Crs",
+          "in" : "header",
+          "description" : "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "epsg:28992" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Geslaagd",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              },
+              "Content-Crs" : {
+                "$ref" : "#/components/headers/contentCrs"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PandHalCollectie"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "412" : {
+            "description" : "Precondition failed",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.13 412 Precondition Failed",
+                  "title" : "Precondition Failed",
+                  "status" : 412,
+                  "detail" : "The precondition given in one or more of the request-header fields evaluated to false when it was tested on the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "preconditionFailed"
+                }
+              }
+            }
+          },
+          "415" : {
+            "description" : "Unsupported Media Type",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type",
+                  "title" : "Unsupported Media Type",
+                  "status" : 415,
+                  "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "unsupported"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "apiKeyBAG" : [ ]
+        } ]
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "ZoekResultaat" : {
+        "type" : "object",
+        "properties" : {
+          "omschrijving" : {
+            "type" : "string",
+            "description" : "Omschrijving van het zoekresultaat"
+          },
+          "identificatie" : {
+            "type" : "string",
+            "description" : "Identificatie van het zoekresultaat"
+          }
+        },
+        "description" : "Resultaat van een zoekoperatie dat je kunt gebruiken om een adres te vinden met /adressen"
+      },
+      "ZoekResultaatHal" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ZoekResultaat"
+        }, {
+          "properties" : {
+            "_links" : {
+              "$ref" : "#/components/schemas/ZoekResultaat_links"
+            }
+          }
+        } ]
+      },
+      "ZoekResultaat_links" : {
+        "type" : "object",
+        "properties" : {
+          "adres" : {
+            "$ref" : "#/components/schemas/HalLink"
+          }
+        }
+      },
+      "ZoekResultaatHalCollectie" : {
+        "type" : "object",
+        "properties" : {
+          "_links" : {
+            "$ref" : "#/components/schemas/HalPaginationLinksMetLast"
+          },
+          "_embedded" : {
+            "$ref" : "#/components/schemas/ZoekResultaatHalCollectie__embedded"
+          }
+        },
+        "description" : "Resultaten als lijst"
+      },
+      "Adres" : {
+        "type" : "object",
+        "properties" : {
+          "straat" : {
+            "title" : "openbareruimte naam",
+            "type" : "string",
+            "description" : "Een naam die door de gemeente aan een openbare ruimte is gegeven.",
+            "example" : "Laan van de landinrichtingscommissie Duiven-Westervoort"
+          },
+          "huisnummer" : {
+            "type" : "integer",
+            "description" : "Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.",
+            "example" : 1
+          },
+          "huisletter" : {
+            "type" : "string",
+            "description" : "Een toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven.",
+            "example" : "A"
+          },
+          "huisnummertoevoeging" : {
+            "type" : "string",
+            "description" : "Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.",
+            "example" : "bis"
+          },
+          "postcode" : {
+            "type" : "string",
+            "description" : "De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.",
+            "example" : "6922KZ"
+          },
+          "woonplaats" : {
+            "title" : "woonplaats naam",
+            "type" : "string",
+            "description" : "Een woonplaats is een gedeelte van het grondgebied van de gemeente met een naam.",
+            "example" : "Duiven"
+          }
+        },
+        "description" : "Eigenschappen van het adres die kunnen worden hergebruikt in andere API's waarin adresgegevens worden opgenomen. "
+      },
+      "AdresUitgebreid" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Adres"
+        }, {
+          "properties" : {
+            "korteNaam" : {
+              "maxLength" : 24,
+              "type" : "string",
+              "description" : "De officiële openbareruimtenaam of een verkorte versie. Beiden hebben maximaal 24 tekens.",
+              "example" : "Ln vd l D-Westervoort"
+            },
+            "nummeraanduidingIdentificatie" : {
+              "type" : "string",
+              "description" : "Fungeert ook als identificatie van het adres.",
+              "example" : "0226200000038923"
+            },
+            "openbareRuimteIdentificatie" : {
+              "type" : "string",
+              "example" : "0226300000136166"
+            },
+            "woonplaatsIdentificatie" : {
+              "type" : "string",
+              "example" : "2096"
+            },
+            "adresseerbaarObjectIdentificatie" : {
+              "type" : "string",
+              "example" : "0226010000038820"
+            },
+            "pandIdentificaties" : {
+              "type" : "array",
+              "description" : "Identificatie(s) van het pand of de panden waar het verblijfsobject deel van is.",
+              "items" : {
+                "type" : "string",
+                "example" : "0226100000008856"
+              }
+            },
+            "isNevenadres" : {
+              "type" : "boolean",
+              "description" : "Indicatie dat dit adres een nevenadres is van een adresseerbaar object. Het adres is een hoofdadres als deze indicatie niet wordt meegeleverd."
+            },
+            "geconstateerd" : {
+              "type" : "boolean",
+              "description" : "Indicatie dat dit adres in de registratie is opgenomen door een feitelijke constatering, zonder dat er sprake was van een brondocument/vergunning. Het adres is mogelijk illegaal."
+            },
+            "mogelijkOnjuist" : {
+              "$ref" : "#/components/schemas/AdresMogelijkOnjuist"
+            }
+          },
+          "description" : "Het adres is de benaming van een locatie bestaande uit straatnaam, huisnummer, (mogelijk met huisletter, huisnummertoevoeging, postcode) en woonplaatsnaam. Dit is de vereenvoudigde samenstelling van de officiële naamgeving gebaseerd op woonplaats, openbare ruimte en nummeraanduiding."
+        } ]
+      },
+      "AdresMogelijkOnjuist" : {
+        "type" : "object",
+        "properties" : {
+          "korteNaam" : {
+            "type" : "boolean"
+          },
+          "straat" : {
+            "type" : "boolean"
+          },
+          "huisnummer" : {
+            "type" : "boolean"
+          },
+          "huisletter" : {
+            "type" : "boolean"
+          },
+          "huisnummertoevoeging" : {
+            "type" : "boolean"
+          },
+          "postcode" : {
+            "type" : "boolean"
+          },
+          "woonplaats" : {
+            "type" : "boolean"
+          },
+          "nummeraanduidingIdentificatie" : {
+            "type" : "boolean"
+          },
+          "openbareRuimteIdentificatie" : {
+            "type" : "boolean"
+          },
+          "woonplaatsIdentificatie" : {
+            "type" : "boolean"
+          },
+          "toelichting" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "example" : "Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt."
+            }
+          }
+        },
+        "description" : "Wanneer true is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
+      },
+      "AdresHal" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/AdresHalBasis"
+        }, {
+          "properties" : {
+            "_embedded" : {
+              "$ref" : "#/components/schemas/Adres_embedded"
+            }
+          }
+        } ]
+      },
+      "AdresHalBasis" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/AdresUitgebreid"
+        }, {
+          "properties" : {
+            "_links" : {
+              "$ref" : "#/components/schemas/Adres_links"
+            }
+          }
+        } ]
+      },
+      "AdresHalCollectie" : {
+        "type" : "object",
+        "properties" : {
+          "_links" : {
+            "$ref" : "#/components/schemas/HalPaginationLinksMetLast"
+          },
+          "_embedded" : {
+            "$ref" : "#/components/schemas/AdresHalCollectie__embedded"
+          }
+        }
+      },
+      "Adres_links" : {
+        "type" : "object",
+        "properties" : {
+          "self" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "openbareRuimte" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "nummeraanduiding" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "woonplaats" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "adresseerbaarObject" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "panden" : {
+            "type" : "array",
+            "description" : "Het/de aan het adres gerelateerde pand(en).",
+            "items" : {
+              "$ref" : "#/components/schemas/HalLink"
+            }
+          }
+        }
+      },
+      "Adres_embedded" : {
+        "type" : "object",
+        "properties" : {
+          "openbareRuimte" : {
+            "$ref" : "#/components/schemas/OpenbareRuimteHalBasis"
+          },
+          "nummeraanduiding" : {
+            "$ref" : "#/components/schemas/NummeraanduidingHalBasis"
+          },
+          "woonplaats" : {
+            "$ref" : "#/components/schemas/WoonplaatsHalBasis"
+          }
+        }
+      },
+      "AdresseerbaarObject" : {
+        "type" : "object",
+        "properties" : {
+          "identificatie" : {
+            "type" : "string",
+            "description" : "Dit is de identificatie van een ligplaats, standplaats of verblijfsobject.",
+            "example" : "0226010000038820"
+          },
+          "domein" : {
+            "type" : "string",
+            "description" : "Het domein waartoe de identificatie behoort."
+          },
+          "type" : {
+            "$ref" : "#/components/schemas/TypeAdresseerbaarObject_enum"
+          },
+          "documentdatum" : {
+            "type" : "string",
+            "description" : "De vaststellingsdatum van het brondocument dat de basis is voor opname, wijziging of een verwijdering van een object.",
+            "format" : "date",
+            "example" : "2019-11-22"
+          },
+          "documentnummer" : {
+            "type" : "string",
+            "description" : "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van een woonplaats heeft plaatsgevonden, binnen een gemeente. Alle karakters uit de MES-1 karakterset zijn toegstaan.",
+            "example" : "19SZ2048"
+          },
+          "gebruiksdoelen" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Gebruiksdoel_enum"
+            }
+          },
+          "geconstateerd" : {
+            "type" : "boolean",
+            "description" : "Indicatie dat een standplaats, ligplaats of verblijfsobject in de registratie is opgenomen door een feitelijke constatering, zonder dat er een brondocument aan ten grondslag ligt. Het adresseerbaar object is mogelijk illegaal."
+          },
+          "geometrie" : {
+            "$ref" : "#/components/schemas/PuntOfVlak"
+          },
+          "pandIdentificaties" : {
+            "type" : "array",
+            "description" : "Identificatie(s) van het pand of de panden waar het verblijfsobject deel van is.",
+            "items" : {
+              "type" : "string",
+              "example" : "0226100000008856"
+            }
+          },
+          "nummeraanduidingIdentificaties" : {
+            "type" : "array",
+            "description" : "Identificatie(s) van de hoofd- en nevenadressen van de standplaats, ligplaats of verblijfsobject.",
+            "items" : {
+              "$ref" : "#/components/schemas/NummeraanduidingIdentificatiesArray"
+            }
+          },
+          "oppervlakte" : {
+            "type" : "integer"
+          },
+          "status" : {
+            "$ref" : "#/components/schemas/AdresseerbaarObjectStatus_enum"
+          },
+          "mogelijkOnjuist" : {
+            "$ref" : "#/components/schemas/AdresseerbaarObjectMogelijkOnjuist"
+          }
+        },
+        "description" : "Een adresseerbaarobject is een standplaats, ligplaats of verblijfsobject."
+      },
+      "AdresseerbaarObjectHal" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/AdresseerbaarObjectHalBasis"
+        }, {
+          "properties" : {
+            "_embedded" : {
+              "$ref" : "#/components/schemas/AdresseerbaarObject_embedded"
+            }
+          }
+        } ]
+      },
+      "AdresseerbaarObjectHalBasis" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/AdresseerbaarObject"
+        }, {
+          "properties" : {
+            "_links" : {
+              "$ref" : "#/components/schemas/AdresseerbaarObject_links"
+            }
+          }
+        } ]
+      },
+      "AdresseerbaarObjectMogelijkOnjuist" : {
+        "type" : "object",
+        "properties" : {
+          "gebruiksdoelen" : {
+            "type" : "boolean"
+          },
+          "geometrie" : {
+            "type" : "boolean"
+          },
+          "nummeraanduidingIdentificaties" : {
+            "type" : "boolean"
+          },
+          "pandIdentificaties" : {
+            "type" : "boolean"
+          },
+          "oppervlakte" : {
+            "type" : "boolean"
+          },
+          "status" : {
+            "type" : "boolean"
+          },
+          "toelichting" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "example" : "Locatie/contour mogelijk onjuist."
+            }
+          }
+        },
+        "description" : "Wanneer true is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
+      },
+      "AdresseerbaarObject_embedded" : {
+        "type" : "object",
+        "properties" : {
+          "adressen" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AdresHalBasis"
+            }
+          },
+          "panden" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PandHalBasis"
+            }
+          }
+        }
+      },
+      "AdresseerbaarObject_links" : {
+        "type" : "object",
+        "properties" : {
+          "adressen" : {
+            "type" : "array",
+            "description" : "Link(s) naar het hoofdadres en waar van toepassing de nebvenadressen van het adresseerbaarobject.",
+            "items" : {
+              "$ref" : "#/components/schemas/HalLink"
+            }
+          },
+          "panden" : {
+            "type" : "array",
+            "description" : "Link(s) naar het pand of de panden waar het adresseerbaar object deel van uitmaakt.",
+            "items" : {
+              "$ref" : "#/components/schemas/HalLink"
+            }
+          },
+          "self" : {
+            "$ref" : "#/components/schemas/HalLink"
+          }
+        }
+      },
+      "AdresseerbaarobjectHalCollectie" : {
+        "type" : "object",
+        "properties" : {
+          "_embedded" : {
+            "$ref" : "#/components/schemas/AdresseerbaarobjectHalCollectie__embedded"
+          },
+          "_links" : {
+            "$ref" : "#/components/schemas/HalPaginationLinksMetLast"
+          }
+        }
+      },
+      "AdresseerbaarObjectStatus_enum" : {
+        "type" : "string",
+        "enum" : [ "Plaats aangewezen", "Verblijfsobject gevormd", "Verblijfsobject in gebruik (niet ingemeten)", "Verblijfsobject in gebruik", "Verbouwing verblijfsobject", "Verblijfsobject buiten gebruik" ]
+      },
+      "Gebruiksdoel_enum" : {
+        "type" : "string",
+        "enum" : [ "woonfunctie", "bijeenkomstfunctie", "celfunctie", "gezondheidszorgfunctie", "industriefunctie", "kantoorfunctie", "logiesfunctie", "onderwijsfunctie", "sportfunctie", "winkelfunctie", "overige gebruiksfunctie" ]
+      },
+      "OpenbareRuimte" : {
+        "type" : "object",
+        "properties" : {
+          "identificatie" : {
+            "type" : "string"
+          },
+          "domein" : {
+            "type" : "string",
+            "description" : "Het domein waartoe de identificatie behoort."
+          },
+          "naam" : {
+            "title" : "openbare ruimte naam",
+            "type" : "string",
+            "description" : "De naam die door de gemeente aan een openbare ruimte is gegeven.",
+            "example" : "Laan van de landinrichtingscommissie Duiven-Westervoort"
+          },
+          "type" : {
+            "$ref" : "#/components/schemas/TypeOpenbareRuimte_enum"
+          },
+          "status" : {
+            "$ref" : "#/components/schemas/StatusNaamgeving_enum"
+          },
+          "korteNaam" : {
+            "maxLength" : 24,
+            "type" : "string",
+            "description" : "De officiële openbareruimtenaam of een verkorte versie. Beiden hebben maximaal 24 tekens.",
+            "example" : "Ln vd l D-Westervoort"
+          },
+          "geconstateerd" : {
+            "type" : "boolean",
+            "description" : "Indicator dat een openbare ruimte in de registratie is opgenomen door een feitelijke constatering, zonder dat er een brondocument aan ten grondslag ligt. De openbare ruimte is mogelijk illegaal."
+          },
+          "documentdatum" : {
+            "type" : "string",
+            "description" : "De vaststellingsdatum van het brondocument dat de basis is voor opname, wijziging of een verwijdering van een object.",
+            "format" : "date",
+            "example" : "2010-02-09"
+          },
+          "documentnummer" : {
+            "type" : "string",
+            "description" : "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van een woonplaats heeft plaatsgevonden, binnen een gemeente. Alle karakters uit de MES-1 karakterset zijn toegstaan.",
+            "example" : "BAG-21"
+          },
+          "woonplaatsIdentificatie" : {
+            "type" : "string",
+            "description" : "Een openbare ruimte ligt in een woonplaats.",
+            "example" : "2096"
+          },
+          "mogelijkOnjuist" : {
+            "$ref" : "#/components/schemas/OpenbareRuimteMogelijkOnjuist"
+          }
+        },
+        "description" : "Een buitenruimte met een naam die binnen één woonplaats ligt, bijvoorbeeld een straat of een plein."
+      },
+      "OpenbareRuimteMogelijkOnjuist" : {
+        "type" : "object",
+        "properties" : {
+          "naam" : {
+            "type" : "boolean"
+          },
+          "korteNaam" : {
+            "type" : "boolean"
+          },
+          "type" : {
+            "type" : "boolean"
+          },
+          "status" : {
+            "type" : "boolean"
+          },
+          "woonplaatsIdentificatie" : {
+            "type" : "boolean"
+          },
+          "toelichting" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "example" : "Openbare ruimtenaam komt mogelijk niet overeen met de vermelding in het straatnaambesluit."
+            }
+          }
+        },
+        "description" : "Wanneer true is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
+      },
+      "OpenbareRuimteHalBasis" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/OpenbareRuimte"
+        }, {
+          "properties" : {
+            "_links" : {
+              "$ref" : "#/components/schemas/OpenbareRuimte_links"
+            }
+          }
+        } ]
+      },
+      "OpenbareRuimte_links" : {
+        "type" : "object",
+        "properties" : {
+          "self" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "woonplaats" : {
+            "$ref" : "#/components/schemas/HalLink"
+          }
+        }
+      },
+      "Nummeraanduiding" : {
+        "type" : "object",
+        "properties" : {
+          "identificatie" : {
+            "type" : "string"
+          },
+          "domein" : {
+            "type" : "string",
+            "description" : "Het domein waartoe de identificatie behoort."
+          },
+          "huisnummer" : {
+            "type" : "integer",
+            "description" : "Nummer dat door de gemeente aan een adresseerbaar object is gegeven.",
+            "example" : 1
+          },
+          "huisletter" : {
+            "type" : "string",
+            "description" : "Toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven.",
+            "example" : "A"
+          },
+          "huisnummertoevoeging" : {
+            "type" : "string",
+            "description" : "Toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.",
+            "example" : "bis"
+          },
+          "postcode" : {
+            "type" : "string",
+            "description" : "Door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.",
+            "example" : "6922KZ"
+          },
+          "status" : {
+            "$ref" : "#/components/schemas/StatusNaamgeving_enum"
+          },
+          "geconstateerd" : {
+            "type" : "boolean",
+            "description" : "Indicator dat de nummeraanduiding in de registratie is opgenomen door een feitelijke constatering, zonder dat er sprake was van een brondocument/vergunning. De nummeraanduiding is mogelijk illegaal."
+          },
+          "documentdatum" : {
+            "type" : "string",
+            "description" : "De vaststellingsdatum van het brondocument dat de basis is voor opname, wijziging of een verwijdering van een object.",
+            "format" : "date",
+            "example" : "2019-11-25"
+          },
+          "documentnummer" : {
+            "type" : "string",
+            "description" : "Identificatie van het brondocument dat ten grondslag ligt aan de opname, mutatie of een verwijdering van gegevens.",
+            "example" : "Duiven 25112019"
+          },
+          "woonplaatsIdentificatie" : {
+            "type" : "string",
+            "description" : "Een nummeraanduiding ligt in een woonplaats.",
+            "example" : "2096"
+          },
+          "openbareRuimteIdentificatie" : {
+            "type" : "string",
+            "description" : "Een nummeraanduiding ligt aan een openbare ruimte.",
+            "example" : "0226300000136166"
+          },
+          "mogelijkOnjuist" : {
+            "$ref" : "#/components/schemas/NummeraanduidingMogelijkOnjuist"
+          }
+        },
+        "description" : "Een postcode, huisnummer met mogelijk een huisletter en huisnummertoevoeging die hoort bij een verblijfsobject, een standplaats of een ligplaats."
+      },
+      "NummeraanduidingIdentificatiesArray" : {
+        "type" : "object",
+        "properties" : {
+          "nummeraanduidingIdentificatie" : {
+            "type" : "string",
+            "example" : "0226200000038923"
+          },
+          "isNevenadres" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "NummeraanduidingMogelijkOnjuist" : {
+        "type" : "object",
+        "properties" : {
+          "huisnummer" : {
+            "type" : "boolean"
+          },
+          "huisletter" : {
+            "type" : "boolean"
+          },
+          "huisnummertoevoeging" : {
+            "type" : "boolean"
+          },
+          "postcode" : {
+            "type" : "boolean"
+          },
+          "status" : {
+            "type" : "boolean"
+          },
+          "woonplaatsIdentificatie" : {
+            "type" : "boolean"
+          },
+          "openbareRuimteIdentificatie" : {
+            "type" : "boolean"
+          },
+          "toelichting" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "example" : "Woonplaats bestaat mogelijk niet."
+            }
+          }
+        },
+        "description" : "Wanneer true is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
+      },
+      "NummeraanduidingHalBasis" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Nummeraanduiding"
+        }, {
+          "properties" : {
+            "_links" : {
+              "$ref" : "#/components/schemas/Nummeraanduiding_links"
+            }
+          }
+        } ]
+      },
+      "Nummeraanduiding_links" : {
+        "type" : "object",
+        "properties" : {
+          "self" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "adres" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "openbareRuimte" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "woonplaats" : {
+            "$ref" : "#/components/schemas/HalLink"
+          }
+        }
+      },
+      "Woonplaats" : {
+        "type" : "object",
+        "properties" : {
+          "identificatie" : {
+            "type" : "string"
+          },
+          "domein" : {
+            "type" : "string",
+            "description" : "Het domein waartoe de identificatie behoort."
+          },
+          "naam" : {
+            "type" : "string",
+            "description" : "De naam van de woonplaats.",
+            "example" : "Duiven"
+          },
+          "status" : {
+            "$ref" : "#/components/schemas/StatusWoonplaats_enum"
+          },
+          "geconstateerd" : {
+            "type" : "boolean",
+            "description" : "Indicator dat de woonplaats in de registratie is opgenomen door een feitelijke constatering, zonder dat er een brondocument aan ten grondslag ligt. De woonplaats is mogelijk illegaal."
+          },
+          "documentdatum" : {
+            "type" : "string",
+            "description" : "De vaststellingsdatum van het brondocument dat de basis is voor opname, wijziging of een verwijdering van een object.",
+            "format" : "date",
+            "example" : "2009-02-09"
+          },
+          "documentnummer" : {
+            "type" : "string",
+            "description" : "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van een woonplaats heeft plaatsgevonden, binnen een gemeente. Alle karakters uit de MES-1 karakterset zijn toegstaan.",
+            "example" : "09.0898"
+          },
+          "mogelijkOnjuist" : {
+            "$ref" : "#/components/schemas/WoonplaatsMogelijkOnjuist"
+          }
+        },
+        "description" : "Een woonplaats is een gedeelte van het grondgebied van de gemeente met een naam."
+      },
+      "WoonplaatsMogelijkOnjuist" : {
+        "type" : "object",
+        "properties" : {
+          "naam" : {
+            "type" : "boolean"
+          },
+          "geometrie" : {
+            "type" : "boolean"
+          },
+          "status" : {
+            "type" : "boolean"
+          },
+          "toelichting" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "example" : "Woonplaats bestaat mogelijk niet."
+            }
+          }
+        },
+        "description" : "Wanneer true is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
+      },
+      "WoonplaatsHalBasis" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Woonplaats"
+        }, {
+          "properties" : {
+            "_links" : {
+              "$ref" : "#/components/schemas/Woonplaats_links"
+            }
+          }
+        } ]
+      },
+      "WoonplaatsHal" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/WoonplaatsHalBasis"
+        }, {
+          "properties" : {
+            "_embedded" : {
+              "$ref" : "#/components/schemas/Woonplaats_embedded"
+            }
+          }
+        } ]
+      },
+      "Woonplaats_links" : {
+        "type" : "object",
+        "properties" : {
+          "self" : {
+            "$ref" : "#/components/schemas/HalLink"
+          }
+        }
+      },
+      "Woonplaats_embedded" : {
+        "type" : "object",
+        "properties" : {
+          "geometrie" : {
+            "$ref" : "#/components/schemas/VlakOfMultivlak"
+          }
+        }
+      },
+      "Pand" : {
+        "type" : "object",
+        "properties" : {
+          "identificatie" : {
+            "type" : "string",
+            "description" : "De unieke aanduiding van een pand. Elk pand waarvan gegevens zijn opgenomen in de BAG wordt uniek aangeduid door middel van een identificatiecode."
+          },
+          "domein" : {
+            "type" : "string",
+            "description" : "Het domein waartoe de identificatie behoort."
+          },
+          "geometrie" : {
+            "$ref" : "#/components/schemas/polygonGeoJSON"
+          },
+          "oorspronkelijkBouwjaar" : {
+            "type" : "integer",
+            "description" : "Het jaar waarin een pand oorspronkelijk als bouwkundig gereed is wordt opgeleverd. Door de gemeente wordt een inschatting gemaakt van het bouwjaar, en aangepast als het pand wordt opgeleverd. Wijzigingen aan een pand na oplevering leiden niet tot wijziging van het bouwjaar.",
+            "example" : 1991
+          },
+          "status" : {
+            "$ref" : "#/components/schemas/StatusPand_enum"
+          },
+          "geconstateerd" : {
+            "type" : "boolean",
+            "description" : "Indicatie dat het pand in de registratie is opgenomen door een feitelijke constatering, zonder dat er sprake was van een brondocument/vergunning. Het pand is mogelijk illegaal."
+          },
+          "documentdatum" : {
+            "type" : "string",
+            "description" : "De vaststellingsdatum van het brondocument dat de basis is voor opname, wijziging of een verwijdering van een object.",
+            "format" : "date",
+            "example" : "2009-05-12"
+          },
+          "documentnummer" : {
+            "type" : "string",
+            "description" : "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van een woonplaats heeft plaatsgevonden, binnen een gemeente. Alle karakters uit de MES-1 karakterset zijn toegstaan.",
+            "example" : "09.BW.0273"
+          },
+          "adresseerbaarObjectIdentificaties" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "example" : "0226010000038820"
+            }
+          },
+          "nummeraanduidingIdentificaties" : {
+            "type" : "array",
+            "description" : "Identificatie(s) van de hoofd- en nevenadressen van het pand.",
+            "items" : {
+              "$ref" : "#/components/schemas/NummeraanduidingIdentificatiesArray"
+            }
+          },
+          "mogelijkOnjuist" : {
+            "$ref" : "#/components/schemas/PandMogelijkOnjuist"
+          }
+        },
+        "description" : "Een pand is een bouwkundige, constructief zelfstandige eenheid die direct en duurzaam met de aarde is verbonden en betreedbaar en afsluitbaar is."
+      },
+      "PandMogelijkOnjuist" : {
+        "type" : "object",
+        "properties" : {
+          "geometrie" : {
+            "type" : "boolean"
+          },
+          "oorspronkelijkBouwjaar" : {
+            "type" : "boolean"
+          },
+          "status" : {
+            "type" : "boolean"
+          },
+          "toelichting" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "example" : "Mogelijk is de bouw al gereed of is het pand niet gerealiseerd."
+            }
+          }
+        },
+        "description" : "Wanneer true is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
+      },
+      "PandHalBasis" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Pand"
+        }, {
+          "properties" : {
+            "_links" : {
+              "$ref" : "#/components/schemas/Pand_links"
+            }
+          }
+        } ]
+      },
+      "Pand_links" : {
+        "type" : "object",
+        "properties" : {
+          "self" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "adressen" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/HalLink"
+            }
+          },
+          "adresseerbareObjecten" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/HalLink"
+            }
+          }
+        }
+      },
+      "PandHalCollectie" : {
+        "type" : "object",
+        "properties" : {
+          "_links" : {
+            "$ref" : "#/components/schemas/HalCollectionLinks"
+          },
+          "_embedded" : {
+            "$ref" : "#/components/schemas/PandHalCollectie__embedded"
+          }
+        }
+      },
+      "StatusNaamgeving_enum" : {
+        "type" : "string",
+        "description" : "Een aanduiding van alle waarden die de status van een openbare ruimte of een nummeraanduiding kan aannemen.",
+        "enum" : [ "Naamgeving uitgegeven" ]
+      },
+      "StatusPand_enum" : {
+        "type" : "string",
+        "description" : "Een codering van de verschillende waarden die de status van een pand kan aannemen.",
+        "enum" : [ "Bouwvergunning verleend", "Bouw gestart", "Pand in gebruik (niet ingemeten)", "Pand in gebruik", "Verbouwing pand", "Sloopvergunning verleend", "Pand buiten gebruik" ]
+      },
+      "StatusWoonplaats_enum" : {
+        "type" : "string",
+        "description" : "Een aanduiding van alle waarden die de status van een woonplaats kan aannemen.",
+        "enum" : [ "Woonplaats aangewezen" ]
+      },
+      "TypeAdresseerbaarObject_enum" : {
+        "type" : "string",
+        "enum" : [ "verblijfsobject", "standplaats", "ligplaats" ]
+      },
+      "TypeOpenbareRuimte_enum" : {
+        "type" : "string",
+        "description" : "Een codering van de verschillende waarden die de typering van een openbare ruimte kan aannemen.",
+        "enum" : [ "Weg", "Water", "Spoorbaan", "Terrein", "Kunstwerk", "Landschappelijk gebied", "Administratief gebied" ]
+      },
+      "PuntOfVlak" : {
+        "type" : "object",
+        "properties" : {
+          "punt" : {
+            "$ref" : "#/components/schemas/pointGeoJSON"
+          },
+          "vlak" : {
+            "$ref" : "#/components/schemas/polygonGeoJSON"
+          }
+        },
+        "description" : "Een samengesteld geometriegegevenstype waarbij wordt afgedwongen dat voor de geometrie een keuze gemaakt moet worden tussen een punt of een vlak."
+      },
+      "VlakOfMultivlak" : {
+        "type" : "object",
+        "properties" : {
+          "vlak" : {
+            "$ref" : "#/components/schemas/polygonGeoJSON"
+          },
+          "multivlak" : {
+            "$ref" : "#/components/schemas/multipolygonGeoJSON"
+          }
+        },
+        "description" : "Een samengesteld geometriegegevenstype waarbij wordt afgedwongen dat voor de geometrie een keuze gemaakt moet worden tussen een vlak (GM_Surface) of een multivlak (GM_MultiSurface)."
+      },
+      "BadRequestFoutbericht" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Foutbericht"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "invalidParams" : {
+              "type" : "array",
+              "description" : "Foutmelding per fout in een parameter. Alle gevonden fouten worden één keer teruggemeld.",
+              "items" : {
+                "$ref" : "#/components/schemas/InvalidParams"
+              }
+            }
+          }
+        } ]
+      },
+      "Foutbericht" : {
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string",
+            "description" : "Link naar meer informatie over deze fout",
+            "format" : "uri"
+          },
+          "title" : {
+            "type" : "string",
+            "description" : "Beschrijving van de fout"
+          },
+          "status" : {
+            "type" : "integer",
+            "description" : "Http status code"
+          },
+          "detail" : {
+            "type" : "string",
+            "description" : "Details over de fout"
+          },
+          "instance" : {
+            "type" : "string",
+            "description" : "Uri van de aanroep die de fout heeft veroorzaakt",
+            "format" : "uri"
+          },
+          "code" : {
+            "minLength" : 1,
+            "type" : "string",
+            "description" : "Systeemcode die het type fout aangeeft"
+          }
+        },
+        "description" : "Terugmelding bij een fout. JSON representatie in lijn met [RFC7807](https://tools.ietf.org/html/rfc7807)."
+      },
+      "InvalidParams" : {
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string",
+            "format" : "uri",
+            "example" : "https://www.vng.nl/realisatie/api/{major-versie}/validaties/integer"
+          },
+          "name" : {
+            "type" : "string",
+            "description" : "Naam van de parameter",
+            "example" : "verblijfplaats__huisnummer"
+          },
+          "code" : {
+            "minLength" : 1,
+            "type" : "string",
+            "description" : "Systeemcode die het type fout aangeeft",
+            "example" : "integer"
+          },
+          "reason" : {
+            "type" : "string",
+            "description" : "Beschrijving van de fout op de parameterwaarde",
+            "example" : "Waarde is geen geldige integer."
+          }
+        },
+        "description" : "Details over fouten in opgegeven parameters"
+      },
+      "HalLink" : {
+        "required" : [ "href" ],
+        "type" : "object",
+        "properties" : {
+          "href" : {
+            "$ref" : "#/components/schemas/Href"
+          },
+          "templated" : {
+            "type" : "boolean"
+          },
+          "title" : {
+            "type" : "string",
+            "description" : "Voor mens leesbaar label bij de link"
+          }
+        },
+        "description" : "De Link Object zoals gespecificeerd in https://tools.ietf.org/html/draft-kelly-json-hal-08#section-5"
+      },
+      "Href" : {
+        "type" : "string",
+        "example" : "https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}"
+      },
+      "HalPaginationLinksMetLast" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/HalPaginationLinks"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "last" : {
+              "$ref" : "#/components/schemas/HalPaginationLinksMetLast_last"
+            }
+          }
+        } ]
+      },
+      "HalPaginationLinks" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/HalCollectionLinks"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "first" : {
+              "$ref" : "#/components/schemas/HalPaginationLinks_first"
+            },
+            "previous" : {
+              "$ref" : "#/components/schemas/HalPaginationLinks_previous"
+            },
+            "next" : {
+              "$ref" : "#/components/schemas/HalPaginationLinks_next"
+            }
+          }
+        } ]
+      },
+      "HalCollectionLinks" : {
+        "type" : "object",
+        "properties" : {
+          "self" : {
+            "$ref" : "#/components/schemas/HalLink"
+          }
+        }
+      },
+      "polygonGeoJSON" : {
+        "required" : [ "coordinates", "type" ],
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string",
+            "enum" : [ "Polygon" ]
+          },
+          "coordinates" : {
+            "type" : "array",
+            "items" : {
+              "minItems" : 4,
+              "type" : "array",
+              "items" : {
+                "minItems" : 2,
+                "type" : "array",
+                "items" : {
+                  "type" : "number"
+                }
+              }
+            }
+          }
+        }
+      },
+      "pointGeoJSON" : {
+        "required" : [ "coordinates", "type" ],
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string",
+            "enum" : [ "Point" ]
+          },
+          "coordinates" : {
+            "minItems" : 2,
+            "type" : "array",
+            "items" : {
+              "type" : "number"
+            }
+          }
+        }
+      },
+      "multipolygonGeoJSON" : {
+        "required" : [ "coordinates", "type" ],
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string",
+            "enum" : [ "MultiPolygon" ]
+          },
+          "coordinates" : {
+            "type" : "array",
+            "items" : {
+              "type" : "array",
+              "items" : {
+                "minItems" : 4,
+                "type" : "array",
+                "items" : {
+                  "minItems" : 2,
+                  "type" : "array",
+                  "items" : {
+                    "type" : "number"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ZoekResultaatHalCollectie__embedded" : {
+        "type" : "object",
+        "properties" : {
+          "zoekresultaten" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ZoekResultaatHal"
+            }
+          }
+        }
+      },
+      "AdresHalCollectie__embedded" : {
+        "type" : "object",
+        "properties" : {
+          "adressen" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AdresHal"
+            }
+          }
+        }
+      },
+      "AdresseerbaarobjectHalCollectie__embedded" : {
+        "type" : "object",
+        "properties" : {
+          "adresseerbareObjecten" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AdresseerbaarObjectHal"
+            }
+          }
+        }
+      },
+      "PandHalCollectie__embedded" : {
+        "type" : "object",
+        "properties" : {
+          "panden" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PandHalBasis"
+            }
+          }
+        }
+      },
+      "HalPaginationLinksMetLast_last" : {
+        "type" : "object",
+        "properties" : {
+          "href" : {
+            "type" : "string",
+            "example" : "/resourcenaam?page=8"
+          },
+          "templated" : {
+            "type" : "boolean"
+          },
+          "title" : {
+            "type" : "string",
+            "example" : "Laatste pagina"
+          }
+        },
+        "description" : "uri voor het opvragen van de laatste pagina van deze collectie"
+      },
+      "HalPaginationLinks_first" : {
+        "type" : "object",
+        "properties" : {
+          "href" : {
+            "type" : "string",
+            "example" : "/resourcenaam?page=1"
+          },
+          "templated" : {
+            "type" : "boolean"
+          },
+          "title" : {
+            "type" : "string",
+            "example" : "Eerste pagina"
+          }
+        },
+        "description" : "uri voor het opvragen van de eerste pagina van deze collectie"
+      },
+      "HalPaginationLinks_previous" : {
+        "type" : "object",
+        "properties" : {
+          "href" : {
+            "type" : "string",
+            "example" : "/resourcenaam?page=3"
+          },
+          "templated" : {
+            "type" : "boolean"
+          },
+          "title" : {
+            "type" : "string",
+            "example" : "Vorige pagina"
+          }
+        },
+        "description" : "uri voor het opvragen van de vorige pagina van deze collectie"
+      },
+      "HalPaginationLinks_next" : {
+        "type" : "object",
+        "properties" : {
+          "href" : {
+            "type" : "string",
+            "example" : "/resourcenaam?page=5"
+          },
+          "templated" : {
+            "type" : "boolean"
+          },
+          "title" : {
+            "type" : "string",
+            "example" : "Volgende pagina"
+          }
+        },
+        "description" : "uri voor het opvragen van de volgende pagina van deze collectie"
+      }
+    },
+    "parameters" : {
+      "zoek" : {
+        "name" : "zoek",
+        "in" : "query",
+        "description" : "Zoekterm op postcode, woonplaats, straatnaam, huisnummer, huisletter, huisnummertoevoeging",
+        "required" : true,
+        "style" : "form",
+        "explode" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      },
+      "zoekresultaatIdentificatie" : {
+        "name" : "zoekresultaatIdentificatie",
+        "in" : "query",
+        "description" : "De identificatie van een zoekresultaat van het endpoint get /adressen/zoek",
+        "required" : false,
+        "style" : "form",
+        "explode" : true,
+        "schema" : {
+          "type" : "string"
+        }
+      },
+      "locatie-query" : {
+        "name" : "locatie",
+        "in" : "query",
+        "description" : "Coordinaten van een locatie die als query-parmeter gebruikt wordt om een object te zoeken. Let op, explode is false dus het formaat is ?locatie=194602.722,464154.308",
+        "required" : false,
+        "style" : "form",
+        "explode" : false,
+        "schema" : {
+          "maxItems" : 2,
+          "minItems" : 2,
+          "type" : "array",
+          "example" : [ 196733.51, 439931.89 ],
+          "items" : {
+            "type" : "number"
+          }
+        }
+      },
+      "nummeraanduidingIdentificatie-query" : {
+        "name" : "nummeraanduidingIdentificatie",
+        "in" : "query",
+        "description" : "Identificatie van een nummeraanduiding uit de BAG. Deze is 16 cijfers lang.",
+        "required" : false,
+        "style" : "form",
+        "explode" : true,
+        "schema" : {
+          "pattern" : "^[0-9]{16}$",
+          "type" : "string",
+          "example" : "0226200000038923"
+        }
+      },
+      "pandIdentificatie-query" : {
+        "name" : "pandIdentificatie",
+        "in" : "query",
+        "description" : "Identificatie van een pand uit de BAG. Deze is 16 cijfers lang.",
+        "required" : false,
+        "style" : "form",
+        "explode" : true,
+        "schema" : {
+          "pattern" : "^[0-9]{16}$",
+          "type" : "string",
+          "example" : "0226100000008856"
+        }
+      },
+      "adresseerbaarObjectIdentificatie-query" : {
+        "name" : "adresseerbaarObjectIdentificatie",
+        "in" : "query",
+        "description" : "De identificatie van een adresserbaar object uit de BAG. Dit kan een verblijfsobject, een standplaats of een ligplaats zijn.",
+        "required" : false,
+        "style" : "form",
+        "explode" : true,
+        "schema" : {
+          "pattern" : "^[0-9]{16}$",
+          "type" : "string",
+          "example" : "0226010000038820"
+        }
+      },
+      "nummeraanduidingidentificatie" : {
+        "name" : "nummeraanduidingidentificatie",
+        "in" : "path",
+        "description" : "Identificatie van een nummeraanduiding uit de BAG. Deze is 16 cijfers lang.",
+        "required" : true,
+        "style" : "simple",
+        "explode" : false,
+        "schema" : {
+          "pattern" : "^[0-9]{16}$",
+          "type" : "string",
+          "example" : "0226200000038923"
+        }
+      },
+      "adresseerbaarobjectidentificatie" : {
+        "name" : "adresseerbaarobjectidentificatie",
+        "in" : "path",
+        "description" : "De identificatie van een adresserbaar object uit de BAG. Dit kan een verblijfsobject, een standplaats of een ligplaats zijn.",
+        "required" : true,
+        "style" : "simple",
+        "explode" : false,
+        "schema" : {
+          "pattern" : "^[0-9]{16}$",
+          "type" : "string",
+          "example" : "0226010000038820"
+        }
+      },
+      "pandidentificatie" : {
+        "name" : "pandidentificatie",
+        "in" : "path",
+        "description" : "Identificatie van een pand uit de BAG. Deze is 16 cijfers lang.",
+        "required" : true,
+        "style" : "simple",
+        "explode" : false,
+        "schema" : {
+          "pattern" : "^[0-9]{16}$",
+          "type" : "string",
+          "example" : "0226100000008856"
+        }
+      },
+      "woonplaatsidentificatie" : {
+        "name" : "woonplaatsidentificatie",
+        "in" : "path",
+        "description" : "Identificatie van een object uit de BAG. Deze is 4 lang bij een woonplaats en 16 lang bij de andere objecten.",
+        "required" : true,
+        "style" : "simple",
+        "explode" : false,
+        "schema" : {
+          "pattern" : "^[0-9]{3}[1-9]|[0-9]{2}[1-9][0-9]|[0-9][1-9][0-9]{2}|[1-9][0-9]{3}$",
+          "type" : "string",
+          "description" : "Deze wordt gebruikt in de operation, bv. /woonplaatsen/0123. Waarde: 0001-9999.",
+          "example" : "2096"
+        }
+      },
+      "openbareruimteidentificatie" : {
+        "name" : "openbareruimteidentificatie",
+        "in" : "path",
+        "description" : "Identificatie van een object uit de BAG. Deze is 4 lang bij een woonplaats en 16 lang bij de andere objecten.",
+        "required" : true,
+        "style" : "simple",
+        "explode" : false,
+        "schema" : {
+          "pattern" : "^[0-9]{16}$",
+          "type" : "string",
+          "example" : "0226300000136166"
+        }
+      }
+    },
+    "headers" : {
+      "api_version" : {
+        "schema" : {
+          "type" : "string",
+          "description" : "Geeft een specifieke API-versie aan in de context van een specifieke aanroep.",
+          "example" : "1.0.0"
+        }
+      },
+      "warning" : {
+        "schema" : {
+          "type" : "string",
+          "description" : "zie RFC 7234. In het geval een major versie wordt uitgefaseerd, gebruiken we warn-code 299 (\"Miscellaneous Persistent Warning\") en het API end-point (inclusief versienummer) als de warn-agent van de warning, gevolgd door de warn-text met de human-readable waarschuwing",
+          "example" : "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie hier de documentatie: https://omgevingswet.../api/.../v1\"."
+        }
+      },
+      "contentCrs" : {
+        "description" : "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel.",
+        "schema" : {
+          "type" : "string",
+          "enum" : [ "epsg:28992" ]
+        }
+      }
+    },
+    "securitySchemes" : {
+      "apiKeyBAG" : {
+        "type" : "apiKey",
+        "description" : "De API-key die je hebt gekregen dient bij elke request via de `X-Api-Key` request header meegestuurd te worden. Indien deze niet juist wordt meegestuurd, of het een ongeldige key betreft, zul je de foutmelding `403 Forbidden` terugkrijgen.",
+        "name" : "X-Api-Key",
+        "in" : "header"
+      }
+    }
+  }
+}

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -59,16 +59,12 @@ paths:
           default: 20
       responses:
         "200":
-          description: Zoek adres geslaagd
+          description: Geslaagd
           headers:
             api-version:
               $ref: '#/components/headers/api_version'
             warning:
               $ref: '#/components/headers/warning'
-            X-Pagination-Page:
-              $ref: '#/components/headers/X_Pagination_Page'
-            X-Pagination-Limit:
-              $ref: '#/components/headers/X_Pagination_Limit'
           content:
             application/hal+json:
               schema:
@@ -236,8 +232,7 @@ paths:
           example: "0226010000038820"
       - name: zoekresultaatIdentificatie
         in: query
-        description: De identificatie van een gekozen zoekresultaat uit de zoekResultatenHalCollectie
-          verkregen bij een zoek-operatie
+        description: De identificatie van een zoekresultaat van het endpoint get /adressen/zoek
         required: false
         style: form
         explode: true
@@ -283,14 +278,12 @@ paths:
           default: 20
       responses:
         "200":
-          description: Bevraging raadpleegAdresMetZoekResultaatIdentificatie geslaagd
+          description: Geslaagd
           headers:
             api-version:
               $ref: '#/components/headers/api_version'
             warning:
               $ref: '#/components/headers/warning'
-            Content-Crs:
-              $ref: '#/components/headers/contentCrs'
           content:
             application/hal+json:
               schema:
@@ -469,14 +462,12 @@ paths:
           type: string
       responses:
         "200":
-          description: raadpleegAdresMetNumId geslaagd
+          description: Geslaagd
           headers:
             api-version:
               $ref: '#/components/headers/api_version'
             warning:
               $ref: '#/components/headers/warning'
-            Content-Crs:
-              $ref: '#/components/headers/contentCrs'
           content:
             application/hal+json:
               schema:
@@ -1929,9 +1920,8 @@ paths:
       - Pand
       summary: vindt panden
       description: Zoek actuele panden met de identificatie van een adresseerbaar
-        object, nummeraanduiding of een locatie. Gebruik de fields parameter als je
-        alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties
-        fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature).
+        object of een locatie. Gebruik de fields parameter als je alleen specifieke
+        velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature).
       operationId: raadpleegPanden
       parameters:
       - name: adresseerbaarObjectIdentificatie
@@ -1945,17 +1935,6 @@ paths:
           pattern: ^[0-9]{16}$
           type: string
           example: "0226010000038820"
-      - name: nummeraanduidingIdentificatie
-        in: query
-        description: Identificatie van een nummeraanduiding uit de BAG. Deze is 16
-          cijfers lang.
-        required: false
-        style: form
-        explode: true
-        schema:
-          pattern: ^[0-9]{16}$
-          type: string
-          example: "0226200000038923"
       - name: locatie
         in: query
         description: Coordinaten van een locatie die als query-parmeter gebruikt wordt
@@ -2322,11 +2301,8 @@ components:
               of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg
               kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen,
               of in geen enkele woonplaats ligt.
-      description: Wanneer hier een property is opgenomen met de waarde true, dan
-        is de waarde van het gelijknamige property in de resource mogelijk onjuist.
-        De juistheid van dit gegeven wordt op dit moment onderzocht. Onder property
-        toelichting wordt toegelicht wat er mogelijk onjuist is aan het betreffende
-        gegeven.
+      description: Wanneer true is de waarde mogelijk onjuist en wordt juistheid op
+        dit moment onderzocht. Zie toelichting.
     AdresHal:
       allOf:
       - $ref: '#/components/schemas/AdresHalBasis'
@@ -2462,11 +2438,8 @@ components:
           items:
             type: string
             example: Locatie/contour mogelijk onjuist.
-      description: Wanneer hier een property is opgenomen met de waarde true, dan
-        is de waarde van het gelijknamige property in de resource mogelijk onjuist.
-        De juistheid van dit gegeven wordt op dit moment onderzocht. Onder property
-        toelichting wordt toegelicht wat er mogelijk onjuist is aan het betreffende
-        gegeven.
+      description: Wanneer true is de waarde mogelijk onjuist en wordt juistheid op
+        dit moment onderzocht. Zie toelichting.
     AdresseerbaarObject_embedded:
       type: object
       properties:
@@ -2593,8 +2566,8 @@ components:
             type: string
             example: Openbare ruimtenaam komt mogelijk niet overeen met de vermelding
               in het straatnaambesluit.
-      description: De waarde is mogelijk onjuist. De juistheid van dit gegeven wordt
-        op dit moment onderzocht (zie toelichting).
+      description: Wanneer true is de waarde mogelijk onjuist en wordt juistheid op
+        dit moment onderzocht. Zie toelichting.
     OpenbareRuimteHalBasis:
       allOf:
       - $ref: '#/components/schemas/OpenbareRuimte'
@@ -2696,8 +2669,8 @@ components:
           items:
             type: string
             example: Woonplaats bestaat mogelijk niet.
-      description: De waarde is mogelijk onjuist. De juistheid van dit gegeven wordt
-        op dit moment onderzocht (zie toelichting).
+      description: Wanneer true is de waarde mogelijk onjuist en wordt juistheid op
+        dit moment onderzocht. Zie toelichting.
     NummeraanduidingHalBasis:
       allOf:
       - $ref: '#/components/schemas/Nummeraanduiding'
@@ -2765,12 +2738,8 @@ components:
           items:
             type: string
             example: Woonplaats bestaat mogelijk niet.
-      description: Wanneer hier een property is opgenomen met de waarde true, dan
-        is de waarde van het gelijknamige property in de resource mogelijk onjuist.
-        De juistheid van dit gegeven wordt op dit moment onderzocht. Onder property
-        toelichting wordt toegelicht wat er mogelijk onjuist is aan het betreffende
-        gegeven. Wanneer property geometrie is opgenomen met de waarde true, dan is
-        de embedded geometrie mogelijk onjuist.
+      description: Wanneer true is de waarde mogelijk onjuist en wordt juistheid op
+        dit moment onderzocht. Zie toelichting.
     WoonplaatsHalBasis:
       allOf:
       - $ref: '#/components/schemas/Woonplaats'
@@ -2861,8 +2830,8 @@ components:
           items:
             type: string
             example: Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.
-      description: De juistheid van dit gegeven wordt op dit moment onderzocht (zie
-        toelichting).
+      description: Wanneer true is de waarde mogelijk onjuist en wordt juistheid op
+        dit moment onderzocht. Zie toelichting.
     PandHalBasis:
       allOf:
       - $ref: '#/components/schemas/Pand'
@@ -3194,8 +3163,7 @@ components:
     zoekresultaatIdentificatie:
       name: zoekresultaatIdentificatie
       in: query
-      description: De identificatie van een gekozen zoekresultaat uit de zoekResultatenHalCollectie
-        verkregen bij een zoek-operatie
+      description: De identificatie van een zoekresultaat van het endpoint get /adressen/zoek
       required: false
       style: form
       explode: true
@@ -3331,16 +3299,6 @@ components:
         example: '299 https://service.../api/.../v1 "Deze versie van de API is verouderd
           en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie
           hier de documentatie: https://omgevingswet.../api/.../v1".'
-    X_Pagination_Page:
-      schema:
-        type: integer
-        description: Huidige pagina.
-        example: 3
-    X_Pagination_Limit:
-      schema:
-        type: integer
-        description: Aantal resultaten per pagina.
-        example: 20
     contentCrs:
       description: CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New
         Nederlands coordinatenstelsel.

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -438,10 +438,9 @@ paths:
       tags:
         - Pand
       summary: "vindt panden"
-      description: "Zoek actuele panden met de identificatie van een adresseerbaar object, nummeraanduiding of een locatie. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)."
+      description: "Zoek actuele panden met de identificatie van een adresseerbaar object of een locatie. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)."
       parameters:
         - $ref: '#/components/parameters/adresseerbaarObjectIdentificatie-query'
-        - $ref: '#/components/parameters/nummeraanduidingIdentificatie-query'
         - $ref: '#/components/parameters/locatie-query'
         - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/parameters/fields'
         - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/parameters/acceptCrs'

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -47,10 +47,6 @@ paths:
               $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version'
             warning:
               $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/warning'
-            X-Pagination-Page:
-              $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Pagination_Page'
-            X-Pagination-Limit:
-              $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Pagination_Limit'
           content:
             application/hal+json:
               schema:

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -705,7 +705,7 @@ components:
             description: "Bij het controleren of een property mogelijkOnjuist is kan het zijn dat er meerdere indicaties voor een property opgenomen zijn. In dat geval zijn er meerdere indicaties waarvan de naam begint met de property-naam"
     AdresMogelijkOnjuist:
       type: object
-      description: "Wanneer "true" is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
+      description: "Wanneer true is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
       properties:
         korteNaam:
           type: boolean
@@ -851,7 +851,7 @@ components:
             $ref: '#/components/schemas/AdresseerbaarObject_links'
     AdresseerbaarObjectMogelijkOnjuist:
       type: object
-      description: "Wanneer "true" is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
+      description: "Wanneer true is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
       properties:
         gebruiksdoelen:
           type: boolean
@@ -977,7 +977,7 @@ components:
           $ref: '#/components/schemas/OpenbareRuimteMogelijkOnjuist'
     OpenbareRuimteMogelijkOnjuist:
         type: object
-        description: "Wanneer "true" is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
+        description: "Wanneer true is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
         properties:
           naam:
             type: boolean
@@ -1069,7 +1069,7 @@ components:
           type: boolean
     NummeraanduidingMogelijkOnjuist:
         type: object
-        description: "Wanneer "true" is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
+        description: "Wanneer true is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
         properties:
           huisnummer:
             type: boolean
@@ -1144,7 +1144,7 @@ components:
           $ref: "#/components/schemas/WoonplaatsMogelijkOnjuist"
     WoonplaatsMogelijkOnjuist:
       type: object
-      description: "Wanneer "true" is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
+      description: "Wanneer true is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
       properties:
         naam:
           type: boolean
@@ -1227,7 +1227,7 @@ components:
           $ref: '#/components/schemas/PandMogelijkOnjuist'
     PandMogelijkOnjuist:
       type: object
-      description: "Wanneer "true" is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
+      description: "Wanneer true is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
       properties:
         geometrie:
           type: boolean

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -492,7 +492,7 @@ components:
         type: string
 
     zoekresultaatIdentificatie:
-      description: "De identificatie van een gekozen zoekresultaat uit de zoekResultatenHalCollectie verkregen bij een zoek-operatie"
+      description: "De identificatie van een zoekresultaat van het endpoint get /adressen/zoek"
       name: zoekresultaatIdentificatie
       in: query
       required: false
@@ -705,7 +705,7 @@ components:
             description: "Bij het controleren of een property mogelijkOnjuist is kan het zijn dat er meerdere indicaties voor een property opgenomen zijn. In dat geval zijn er meerdere indicaties waarvan de naam begint met de property-naam"
     AdresMogelijkOnjuist:
       type: object
-      description: "Wanneer hier een property is opgenomen met de waarde true, dan is de waarde van het gelijknamige property in de resource mogelijk onjuist. De juistheid van dit gegeven wordt op dit moment onderzocht. Onder property toelichting wordt toegelicht wat er mogelijk onjuist is aan het betreffende gegeven."
+      description: "Wanneer "true" is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
       properties:
         korteNaam:
           type: boolean
@@ -851,7 +851,7 @@ components:
             $ref: '#/components/schemas/AdresseerbaarObject_links'
     AdresseerbaarObjectMogelijkOnjuist:
       type: object
-      description: "Wanneer hier een property is opgenomen met de waarde true, dan is de waarde van het gelijknamige property in de resource mogelijk onjuist. De juistheid van dit gegeven wordt op dit moment onderzocht. Onder property toelichting wordt toegelicht wat er mogelijk onjuist is aan het betreffende gegeven."
+      description: "Wanneer "true" is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
       properties:
         gebruiksdoelen:
           type: boolean
@@ -977,7 +977,7 @@ components:
           $ref: '#/components/schemas/OpenbareRuimteMogelijkOnjuist'
     OpenbareRuimteMogelijkOnjuist:
         type: object
-        description: "De waarde is mogelijk onjuist. De juistheid van dit gegeven wordt op dit moment onderzocht (zie toelichting)."
+        description: "Wanneer "true" is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
         properties:
           naam:
             type: boolean
@@ -1069,7 +1069,7 @@ components:
           type: boolean
     NummeraanduidingMogelijkOnjuist:
         type: object
-        description: "De waarde is mogelijk onjuist. De juistheid van dit gegeven wordt op dit moment onderzocht (zie toelichting)."
+        description: "Wanneer "true" is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
         properties:
           huisnummer:
             type: boolean
@@ -1144,7 +1144,7 @@ components:
           $ref: "#/components/schemas/WoonplaatsMogelijkOnjuist"
     WoonplaatsMogelijkOnjuist:
       type: object
-      description: "Wanneer hier een property is opgenomen met de waarde true, dan is de waarde van het gelijknamige property in de resource mogelijk onjuist. De juistheid van dit gegeven wordt op dit moment onderzocht. Onder property toelichting wordt toegelicht wat er mogelijk onjuist is aan het betreffende gegeven. Wanneer property geometrie is opgenomen met de waarde true, dan is de embedded geometrie mogelijk onjuist."
+      description: "Wanneer "true" is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
       properties:
         naam:
           type: boolean
@@ -1227,7 +1227,7 @@ components:
           $ref: '#/components/schemas/PandMogelijkOnjuist'
     PandMogelijkOnjuist:
       type: object
-      description: "De juistheid van dit gegeven wordt op dit moment onderzocht (zie toelichting)."
+      description: "Wanneer "true" is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting."
       properties:
         geometrie:
           type: boolean

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -41,7 +41,7 @@ paths:
         - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/parameters/pageSize'
       responses:
         '200':
-          description: "Zoek adres geslaagd"
+          description: "Geslaagd"
           headers:
             api-version:
               $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version'
@@ -85,7 +85,7 @@ paths:
         - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/parameters/pageSize'
       responses:
         '200':
-          description: "Bevraging raadpleegAdresMetZoekResultaatIdentificatie geslaagd"
+          description: "Geslaagd"
           headers:
             api-version:
               $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version'
@@ -125,7 +125,7 @@ paths:
         - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/parameters/fields'
       responses:
         '200':
-          description: "raadpleegAdresMetNumId geslaagd"
+          description: "Geslaagd"
           headers:
             api-version:
               $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version'

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -287,10 +287,10 @@ paths:
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/406'
         '412':
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/412'
-        '503':
-          $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/503'
         '500':
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/500'
+        '503':
+          $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/503'
         default:
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/default'
 

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -91,8 +91,6 @@ paths:
               $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version'
             warning:
               $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/warning'
-            Content-Crs:
-              $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/contentCrs'
           content:
             application/hal+json:
               schema:
@@ -133,8 +131,6 @@ paths:
               $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version'
             warning:
               $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/warning'
-            Content-Crs:
-              $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/contentCrs'
           content:
             application/hal+json:
               schema:

--- a/test/BAG-Bevragen-postman-collection.json
+++ b/test/BAG-Bevragen-postman-collection.json
@@ -1,0 +1,5662 @@
+{
+    "item": [
+        {
+            "id": "b3f3b622-31f5-4c49-89c8-6c3360d59832",
+            "name": "adressen",
+            "item": [
+                {
+                    "id": "e22ccef0-0b0c-4695-816b-9e049d1b19c8",
+                    "name": "vindt adressen",
+                    "request": {
+                        "name": "vindt adressen",
+                        "description": {
+                            "content": "Vind een actueel adres met de identificatie van het zoekresultaat uit de operatie get /adressen/zoek, de pandidentificatie of de adresseerbaarobjectidentificatie. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature). Gebruik de expand parameter als je het antwoord wil uitbreiden met (delen van) de gerelateerde resources nummeraanduiding, woonplaats en openbare ruimte, zie [functionele specificaties expand-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "adressen"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "description": "Identificatie van een pand uit de BAG. Deze is 16 cijfers lang.",
+                                    "key": "pandIdentificatie",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "description": "De identificatie van een adresserbaar object uit de BAG. Dit kan een verblijfsobject, een standplaats of een ligplaats zijn.",
+                                    "key": "adresseerbaarObjectIdentificatie",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "description": "De identificatie van een zoekresultaat van het endpoint get /adressen/zoek",
+                                    "key": "zoekresultaatIdentificatie",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "description": "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. In de definitie van het antwoord kun je bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+                                    "key": "expand",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "description": "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+                                    "key": "fields",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "description": "Pagina nummer",
+                                    "key": "page",
+                                    "value": "1"
+                                },
+                                {
+                                    "description": "",
+                                    "key": "pageSize",
+                                    "value": "20"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "X-Api-Key",
+                                "value": "",
+                                "description": "De API-key die je hebt gekregen dient bij elke request via de `X-Api-Key` request header meegestuurd te worden. Indien deze niet juist wordt meegestuurd, of het een ongeldige key betreft, zul je de foutmelding `403 Forbidden` terugkrijgen."
+                            }
+                        ],
+                        "method": "GET",
+                        "auth": {
+                            "type": "noauth"
+                        }
+                    },
+                    "response": [
+                        {
+                            "id": "97a14fe8-0216-4286-928a-228250f555d3",
+                            "name": "Geslaagd",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "zoekresultaatIdentificatie",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "warning",
+                                    "value": "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie hier de documentatie: https://omgevingswet.../api/.../v1\".",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/hal+json"
+                                }
+                            ],
+                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  },\n  \"first\": {\n   \"href\": \"/resourcenaam?page=1\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"Eerste pagina\"\n  },\n  \"previous\": {\n   \"href\": \"/resourcenaam?page=3\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"Vorige pagina\"\n  },\n  \"next\": {\n   \"href\": \"/resourcenaam?page=5\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"Volgende pagina\"\n  },\n  \"last\": {\n   \"href\": \"/resourcenaam?page=8\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"Laatste pagina\"\n  }\n },\n \"_embedded\": {\n  \"adressen\": [\n   {\n    \"straat\": \"Laan van de landinrichtingscommissie Duiven-Westervoort\",\n    \"huisnummer\": 1,\n    \"huisletter\": \"A\",\n    \"huisnummertoevoeging\": \"bis\",\n    \"postcode\": \"6922KZ\",\n    \"woonplaats\": \"Duiven\",\n    \"korteNaam\": \"Ln vd l D-Westervoort\",\n    \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n    \"openbareRuimteIdentificatie\": \"0226300000136166\",\n    \"woonplaatsIdentificatie\": \"2096\",\n    \"adresseerbaarObjectIdentificatie\": \"0226010000038820\",\n    \"pandIdentificaties\": [\n     \"0226100000008856\",\n     \"0226100000008856\"\n    ],\n    \"isNevenadres\": \"<boolean>\",\n    \"geconstateerd\": \"<boolean>\",\n    \"mogelijkOnjuist\": {\n     \"korteNaam\": \"<boolean>\",\n     \"straat\": \"<boolean>\",\n     \"huisnummer\": \"<boolean>\",\n     \"huisletter\": \"<boolean>\",\n     \"huisnummertoevoeging\": \"<boolean>\",\n     \"postcode\": \"<boolean>\",\n     \"woonplaats\": \"<boolean>\",\n     \"nummeraanduidingIdentificatie\": \"<boolean>\",\n     \"openbareRuimteIdentificatie\": \"<boolean>\",\n     \"woonplaatsIdentificatie\": \"<boolean>\",\n     \"toelichting\": [\n      \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\",\n      \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\"\n     ]\n    },\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"openbareRuimte\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"nummeraanduiding\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"woonplaats\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"adresseerbaarObject\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"panden\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ]\n    },\n    \"_embedded\": {\n     \"openbareRuimte\": {\n      \"identificatie\": \"<string>\",\n      \"domein\": \"<string>\",\n      \"naam\": \"Laan van de landinrichtingscommissie Duiven-Westervoort\",\n      \"type\": \"<string>\",\n      \"status\": \"<string>\",\n      \"korteNaam\": \"Ln vd l D-Westervoort\",\n      \"geconstateerd\": \"<boolean>\",\n      \"documentdatum\": {},\n      \"documentnummer\": \"BAG-21\",\n      \"woonplaatsIdentificatie\": \"2096\",\n      \"mogelijkOnjuist\": {\n       \"naam\": \"<boolean>\",\n       \"korteNaam\": \"<boolean>\",\n       \"type\": \"<boolean>\",\n       \"status\": \"<boolean>\",\n       \"woonplaatsIdentificatie\": \"<boolean>\",\n       \"toelichting\": [\n        \"Openbare ruimtenaam komt mogelijk niet overeen met de vermelding in het straatnaambesluit.\",\n        \"Openbare ruimtenaam komt mogelijk niet overeen met de vermelding in het straatnaambesluit.\"\n       ]\n      },\n      \"_links\": {\n       \"self\": {\n        \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n        \"templated\": \"<boolean>\",\n        \"title\": \"<string>\"\n       },\n       \"woonplaats\": {\n        \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n        \"templated\": \"<boolean>\",\n        \"title\": \"<string>\"\n       }\n      }\n     },\n     \"nummeraanduiding\": {\n      \"identificatie\": \"<string>\",\n      \"domein\": \"<string>\",\n      \"huisnummer\": 1,\n      \"huisletter\": \"A\",\n      \"huisnummertoevoeging\": \"bis\",\n      \"postcode\": \"6922KZ\",\n      \"status\": \"<string>\",\n      \"geconstateerd\": \"<boolean>\",\n      \"documentdatum\": {},\n      \"documentnummer\": \"Duiven 25112019\",\n      \"woonplaatsIdentificatie\": \"2096\",\n      \"openbareRuimteIdentificatie\": \"0226300000136166\",\n      \"mogelijkOnjuist\": {\n       \"huisnummer\": \"<boolean>\",\n       \"huisletter\": \"<boolean>\",\n       \"huisnummertoevoeging\": \"<boolean>\",\n       \"postcode\": \"<boolean>\",\n       \"status\": \"<boolean>\",\n       \"woonplaatsIdentificatie\": \"<boolean>\",\n       \"openbareRuimteIdentificatie\": \"<boolean>\",\n       \"toelichting\": [\n        \"Woonplaats bestaat mogelijk niet.\",\n        \"Woonplaats bestaat mogelijk niet.\"\n       ]\n      },\n      \"_links\": {\n       \"self\": {\n        \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n        \"templated\": \"<boolean>\",\n        \"title\": \"<string>\"\n       },\n       \"adres\": {\n        \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n        \"templated\": \"<boolean>\",\n        \"title\": \"<string>\"\n       },\n       \"openbareRuimte\": {\n        \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n        \"templated\": \"<boolean>\",\n        \"title\": \"<string>\"\n       },\n       \"woonplaats\": {\n        \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n        \"templated\": \"<boolean>\",\n        \"title\": \"<string>\"\n       }\n      }\n     },\n     \"woonplaats\": {\n      \"identificatie\": \"<string>\",\n      \"domein\": \"<string>\",\n      \"naam\": \"Duiven\",\n      \"status\": \"<string>\",\n      \"geconstateerd\": \"<boolean>\",\n      \"documentdatum\": {},\n      \"documentnummer\": \"09.0898\",\n      \"mogelijkOnjuist\": {\n       \"naam\": \"<boolean>\",\n       \"geometrie\": \"<boolean>\",\n       \"status\": \"<boolean>\",\n       \"toelichting\": [\n        \"Woonplaats bestaat mogelijk niet.\",\n        \"Woonplaats bestaat mogelijk niet.\"\n       ]\n      },\n      \"_links\": {\n       \"self\": {\n        \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n        \"templated\": \"<boolean>\",\n        \"title\": \"<string>\"\n       }\n      }\n     }\n    }\n   },\n   {\n    \"straat\": \"Laan van de landinrichtingscommissie Duiven-Westervoort\",\n    \"huisnummer\": 1,\n    \"huisletter\": \"A\",\n    \"huisnummertoevoeging\": \"bis\",\n    \"postcode\": \"6922KZ\",\n    \"woonplaats\": \"Duiven\",\n    \"korteNaam\": \"Ln vd l D-Westervoort\",\n    \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n    \"openbareRuimteIdentificatie\": \"0226300000136166\",\n    \"woonplaatsIdentificatie\": \"2096\",\n    \"adresseerbaarObjectIdentificatie\": \"0226010000038820\",\n    \"pandIdentificaties\": [\n     \"0226100000008856\",\n     \"0226100000008856\"\n    ],\n    \"isNevenadres\": \"<boolean>\",\n    \"geconstateerd\": \"<boolean>\",\n    \"mogelijkOnjuist\": {\n     \"korteNaam\": \"<boolean>\",\n     \"straat\": \"<boolean>\",\n     \"huisnummer\": \"<boolean>\",\n     \"huisletter\": \"<boolean>\",\n     \"huisnummertoevoeging\": \"<boolean>\",\n     \"postcode\": \"<boolean>\",\n     \"woonplaats\": \"<boolean>\",\n     \"nummeraanduidingIdentificatie\": \"<boolean>\",\n     \"openbareRuimteIdentificatie\": \"<boolean>\",\n     \"woonplaatsIdentificatie\": \"<boolean>\",\n     \"toelichting\": [\n      \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\",\n      \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\"\n     ]\n    },\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"openbareRuimte\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"nummeraanduiding\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"woonplaats\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"adresseerbaarObject\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"panden\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ]\n    },\n    \"_embedded\": {\n     \"openbareRuimte\": {\n      \"identificatie\": \"<string>\",\n      \"domein\": \"<string>\",\n      \"naam\": \"Laan van de landinrichtingscommissie Duiven-Westervoort\",\n      \"type\": \"<string>\",\n      \"status\": \"<string>\",\n      \"korteNaam\": \"Ln vd l D-Westervoort\",\n      \"geconstateerd\": \"<boolean>\",\n      \"documentdatum\": {},\n      \"documentnummer\": \"BAG-21\",\n      \"woonplaatsIdentificatie\": \"2096\",\n      \"mogelijkOnjuist\": {\n       \"naam\": \"<boolean>\",\n       \"korteNaam\": \"<boolean>\",\n       \"type\": \"<boolean>\",\n       \"status\": \"<boolean>\",\n       \"woonplaatsIdentificatie\": \"<boolean>\",\n       \"toelichting\": [\n        \"Openbare ruimtenaam komt mogelijk niet overeen met de vermelding in het straatnaambesluit.\",\n        \"Openbare ruimtenaam komt mogelijk niet overeen met de vermelding in het straatnaambesluit.\"\n       ]\n      },\n      \"_links\": {\n       \"self\": {\n        \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n        \"templated\": \"<boolean>\",\n        \"title\": \"<string>\"\n       },\n       \"woonplaats\": {\n        \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n        \"templated\": \"<boolean>\",\n        \"title\": \"<string>\"\n       }\n      }\n     },\n     \"nummeraanduiding\": {\n      \"identificatie\": \"<string>\",\n      \"domein\": \"<string>\",\n      \"huisnummer\": 1,\n      \"huisletter\": \"A\",\n      \"huisnummertoevoeging\": \"bis\",\n      \"postcode\": \"6922KZ\",\n      \"status\": \"<string>\",\n      \"geconstateerd\": \"<boolean>\",\n      \"documentdatum\": {},\n      \"documentnummer\": \"Duiven 25112019\",\n      \"woonplaatsIdentificatie\": \"2096\",\n      \"openbareRuimteIdentificatie\": \"0226300000136166\",\n      \"mogelijkOnjuist\": {\n       \"huisnummer\": \"<boolean>\",\n       \"huisletter\": \"<boolean>\",\n       \"huisnummertoevoeging\": \"<boolean>\",\n       \"postcode\": \"<boolean>\",\n       \"status\": \"<boolean>\",\n       \"woonplaatsIdentificatie\": \"<boolean>\",\n       \"openbareRuimteIdentificatie\": \"<boolean>\",\n       \"toelichting\": [\n        \"Woonplaats bestaat mogelijk niet.\",\n        \"Woonplaats bestaat mogelijk niet.\"\n       ]\n      },\n      \"_links\": {\n       \"self\": {\n        \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n        \"templated\": \"<boolean>\",\n        \"title\": \"<string>\"\n       },\n       \"adres\": {\n        \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n        \"templated\": \"<boolean>\",\n        \"title\": \"<string>\"\n       },\n       \"openbareRuimte\": {\n        \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n        \"templated\": \"<boolean>\",\n        \"title\": \"<string>\"\n       },\n       \"woonplaats\": {\n        \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n        \"templated\": \"<boolean>\",\n        \"title\": \"<string>\"\n       }\n      }\n     },\n     \"woonplaats\": {\n      \"identificatie\": \"<string>\",\n      \"domein\": \"<string>\",\n      \"naam\": \"Duiven\",\n      \"status\": \"<string>\",\n      \"geconstateerd\": \"<boolean>\",\n      \"documentdatum\": {},\n      \"documentnummer\": \"09.0898\",\n      \"mogelijkOnjuist\": {\n       \"naam\": \"<boolean>\",\n       \"geometrie\": \"<boolean>\",\n       \"status\": \"<boolean>\",\n       \"toelichting\": [\n        \"Woonplaats bestaat mogelijk niet.\",\n        \"Woonplaats bestaat mogelijk niet.\"\n       ]\n      },\n      \"_links\": {\n       \"self\": {\n        \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n        \"templated\": \"<boolean>\",\n        \"title\": \"<string>\"\n       }\n      }\n     }\n    }\n   }\n  ]\n }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "ba274d8a-3242-4e86-b3fd-effe09a38a99",
+                            "name": "Bad Request",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "zoekresultaatIdentificatie",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request\",\n \"title\": \"Ten minste één parameter moet worden opgegeven.\",\n \"status\": 400,\n \"detail\": \"The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"paramsRequired\",\n \"invalidParams\": [\n  {\n   \"type\": \"https://www.vng.nl/realisatie/api/validaties/integer\",\n   \"name\": \"verblijfplaats__huisnummer\",\n   \"code\": \"integer\",\n   \"reason\": \"Waarde is geen geldige integer.\"\n  }\n ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "4e08483c-2145-46cc-a1b5-2036d210d8f5",
+                            "name": "Unauthorized",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "zoekresultaatIdentificatie",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized\",\n \"title\": \"Niet correct geauthenticeerd.\",\n \"status\": 401,\n \"detail\": \"The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"authentication\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "2ab933bc-ab3f-4fc2-b717-4a1ebe4c9781",
+                            "name": "Forbidden",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "zoekresultaatIdentificatie",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden\",\n \"title\": \"U bent niet geautoriseerd voor deze operatie.\",\n \"status\": 403,\n \"detail\": \"The server understood the request, but is refusing to fulfill it.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"autorisation\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "27ae2bd3-8c00-4e1a-945a-e95af9467370",
+                            "name": "Not Acceptable",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "zoekresultaatIdentificatie",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Acceptable",
+                            "code": 406,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable\",\n \"title\": \"Gevraagde contenttype wordt niet ondersteund.\",\n \"status\": 406,\n \"detail\": \"The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAcceptable\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "1e187409-f1a5-43e4-93a7-62d11de3bcea",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "zoekresultaatIdentificatie",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error\",\n \"title\": \"Interne server fout.\",\n \"status\": 500,\n \"detail\": \"The server encountered an unexpected condition which prevented it from fulfilling the request.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"serverError\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "4e874194-5974-4dc0-a4e4-66b3ae24dbe4",
+                            "name": "Service Unavailable",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "zoekresultaatIdentificatie",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Service Unavailable",
+                            "code": 503,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable\",\n \"title\": \"Bronservice {bron} is tijdelijk niet beschikbaar.\",\n \"status\": 503,\n \"detail\": \"The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAvailable\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "907507e3-bf1d-4e62-95cc-0d99681e890b",
+                            "name": "Er is een onverwachte fout opgetreden",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "zoekresultaatIdentificatie",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"<uri>\",\n \"title\": \"<string>\",\n \"status\": \"<integer>\",\n \"detail\": \"<string>\",\n \"instance\": \"<uri>\",\n \"code\": \"<string>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": []
+                },
+                {
+                    "id": "a10cba69-7b88-486a-bd63-2ebb3c1d6132",
+                    "name": "\"fuzzy\" zoeken van adressen",
+                    "request": {
+                        "name": "\"fuzzy\" zoeken van adressen",
+                        "description": {
+                            "content": "Free query zoeken van adressen met postcode, woonplaats, straatnaam, huisnummer, huisletter, huisnummertoevoeging. Delen van de adressen in het antwoord matchen exact met jouw invoer. Je vindt een adres door de zoekresultaatidentificatie uit het antwoord te gebruiken in get/adressen",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "adressen",
+                                "zoek"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "description": "(Required) Zoekterm op postcode, woonplaats, straatnaam, huisnummer, huisletter, huisnummertoevoeging",
+                                    "key": "zoek",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "description": "Pagina nummer",
+                                    "key": "page",
+                                    "value": "1"
+                                },
+                                {
+                                    "description": "",
+                                    "key": "pageSize",
+                                    "value": "20"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "X-Api-Key",
+                                "value": "",
+                                "description": "De API-key die je hebt gekregen dient bij elke request via de `X-Api-Key` request header meegestuurd te worden. Indien deze niet juist wordt meegestuurd, of het een ongeldige key betreft, zul je de foutmelding `403 Forbidden` terugkrijgen."
+                            }
+                        ],
+                        "method": "GET",
+                        "auth": {
+                            "type": "noauth"
+                        }
+                    },
+                    "response": [
+                        {
+                            "id": "3bbad545-84ba-431e-8ce8-1d4542814b7f",
+                            "name": "Geslaagd",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        "zoek"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "zoek",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "warning",
+                                    "value": "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie hier de documentatie: https://omgevingswet.../api/.../v1\".",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/hal+json"
+                                }
+                            ],
+                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  },\n  \"first\": {\n   \"href\": \"/resourcenaam?page=1\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"Eerste pagina\"\n  },\n  \"previous\": {\n   \"href\": \"/resourcenaam?page=3\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"Vorige pagina\"\n  },\n  \"next\": {\n   \"href\": \"/resourcenaam?page=5\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"Volgende pagina\"\n  },\n  \"last\": {\n   \"href\": \"/resourcenaam?page=8\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"Laatste pagina\"\n  }\n },\n \"_embedded\": {\n  \"zoekresultaten\": [\n   {\n    \"omschrijving\": \"<string>\",\n    \"identificatie\": \"<string>\",\n    \"_links\": {\n     \"adres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     }\n    }\n   },\n   {\n    \"omschrijving\": \"<string>\",\n    \"identificatie\": \"<string>\",\n    \"_links\": {\n     \"adres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     }\n    }\n   }\n  ]\n }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "f7304a4d-4428-4dc7-9ad3-58e4251bcd91",
+                            "name": "Bad Request",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        "zoek"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "zoek",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request\",\n \"title\": \"Ten minste één parameter moet worden opgegeven.\",\n \"status\": 400,\n \"detail\": \"The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"paramsRequired\",\n \"invalidParams\": [\n  {\n   \"type\": \"https://www.vng.nl/realisatie/api/validaties/integer\",\n   \"name\": \"verblijfplaats__huisnummer\",\n   \"code\": \"integer\",\n   \"reason\": \"Waarde is geen geldige integer.\"\n  }\n ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "7e4ee6cf-2b86-4dba-a8c2-086dcd258d49",
+                            "name": "Unauthorized",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        "zoek"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "zoek",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized\",\n \"title\": \"Niet correct geauthenticeerd.\",\n \"status\": 401,\n \"detail\": \"The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"authentication\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "9595e50e-e9c8-4b6b-99ad-9e906c40c30a",
+                            "name": "Forbidden",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        "zoek"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "zoek",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden\",\n \"title\": \"U bent niet geautoriseerd voor deze operatie.\",\n \"status\": 403,\n \"detail\": \"The server understood the request, but is refusing to fulfill it.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"autorisation\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "6e7438de-aa56-47c1-ba54-ef504e8a6c54",
+                            "name": "Not Acceptable",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        "zoek"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "zoek",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Acceptable",
+                            "code": 406,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable\",\n \"title\": \"Gevraagde contenttype wordt niet ondersteund.\",\n \"status\": 406,\n \"detail\": \"The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAcceptable\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "f897c814-4460-4c4c-8c28-1ab87d308e8a",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        "zoek"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "zoek",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error\",\n \"title\": \"Interne server fout.\",\n \"status\": 500,\n \"detail\": \"The server encountered an unexpected condition which prevented it from fulfilling the request.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"serverError\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "9f54b204-0584-42fc-8538-25163114b35f",
+                            "name": "Service Unavailable",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        "zoek"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "zoek",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Service Unavailable",
+                            "code": 503,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable\",\n \"title\": \"Bronservice {bron} is tijdelijk niet beschikbaar.\",\n \"status\": 503,\n \"detail\": \"The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAvailable\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "437268f1-0d37-4a94-8880-82ca956228de",
+                            "name": "Er is een onverwachte fout opgetreden",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        "zoek"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "zoek",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"<uri>\",\n \"title\": \"<string>\",\n \"status\": \"<integer>\",\n \"detail\": \"<string>\",\n \"instance\": \"<uri>\",\n \"code\": \"<string>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": []
+                },
+                {
+                    "id": "33855e81-38c9-4888-a323-ef22f4f0341b",
+                    "name": "levert een adres",
+                    "request": {
+                        "name": "levert een adres",
+                        "description": {
+                            "content": "Raadpleeg een actueel adres met de nummeraanduiding identificatie. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature). Gebruik de expand parameter als je het antwoord wil uitbreiden met (delen van) de gerelateerde resources nummeraanduiding, woonplaats en openbare ruimte, zie [functionele specificaties expand-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "adressen",
+                                ":nummeraanduidingidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "description": "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. In de definitie van het antwoord kun je bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+                                    "key": "expand",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "description": "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "description": "(Required) Identificatie van een nummeraanduiding uit de BAG. Deze is 16 cijfers lang.",
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "nummeraanduidingidentificatie"
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "X-Api-Key",
+                                "value": "",
+                                "description": "De API-key die je hebt gekregen dient bij elke request via de `X-Api-Key` request header meegestuurd te worden. Indien deze niet juist wordt meegestuurd, of het een ongeldige key betreft, zul je de foutmelding `403 Forbidden` terugkrijgen."
+                            }
+                        ],
+                        "method": "GET",
+                        "auth": {
+                            "type": "noauth"
+                        }
+                    },
+                    "response": [
+                        {
+                            "id": "9545d393-e7e6-460d-bf7b-83f4fa0f8ff9",
+                            "name": "Geslaagd",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        ":nummeraanduidingidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "nummeraanduidingidentificatie"
+                                        }
+                                    ]
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "warning",
+                                    "value": "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie hier de documentatie: https://omgevingswet.../api/.../v1\".",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/hal+json"
+                                }
+                            ],
+                            "body": "{\n \"straat\": \"Laan van de landinrichtingscommissie Duiven-Westervoort\",\n \"huisnummer\": 1,\n \"huisletter\": \"A\",\n \"huisnummertoevoeging\": \"bis\",\n \"postcode\": \"6922KZ\",\n \"woonplaats\": \"Duiven\",\n \"korteNaam\": \"Ln vd l D-Westervoort\",\n \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n \"openbareRuimteIdentificatie\": \"0226300000136166\",\n \"woonplaatsIdentificatie\": \"2096\",\n \"adresseerbaarObjectIdentificatie\": \"0226010000038820\",\n \"pandIdentificaties\": [\n  \"0226100000008856\",\n  \"0226100000008856\"\n ],\n \"isNevenadres\": \"<boolean>\",\n \"geconstateerd\": \"<boolean>\",\n \"mogelijkOnjuist\": {\n  \"korteNaam\": \"<boolean>\",\n  \"straat\": \"<boolean>\",\n  \"huisnummer\": \"<boolean>\",\n  \"huisletter\": \"<boolean>\",\n  \"huisnummertoevoeging\": \"<boolean>\",\n  \"postcode\": \"<boolean>\",\n  \"woonplaats\": \"<boolean>\",\n  \"nummeraanduidingIdentificatie\": \"<boolean>\",\n  \"openbareRuimteIdentificatie\": \"<boolean>\",\n  \"woonplaatsIdentificatie\": \"<boolean>\",\n  \"toelichting\": [\n   \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\",\n   \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\"\n  ]\n },\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  },\n  \"openbareRuimte\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  },\n  \"nummeraanduiding\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  },\n  \"woonplaats\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  },\n  \"adresseerbaarObject\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  },\n  \"panden\": [\n   {\n    \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n    \"templated\": \"<boolean>\",\n    \"title\": \"<string>\"\n   },\n   {\n    \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n    \"templated\": \"<boolean>\",\n    \"title\": \"<string>\"\n   }\n  ]\n },\n \"_embedded\": {\n  \"openbareRuimte\": {\n   \"identificatie\": \"<string>\",\n   \"domein\": \"<string>\",\n   \"naam\": \"Laan van de landinrichtingscommissie Duiven-Westervoort\",\n   \"type\": \"<string>\",\n   \"status\": \"<string>\",\n   \"korteNaam\": \"Ln vd l D-Westervoort\",\n   \"geconstateerd\": \"<boolean>\",\n   \"documentdatum\": {},\n   \"documentnummer\": \"BAG-21\",\n   \"woonplaatsIdentificatie\": \"2096\",\n   \"mogelijkOnjuist\": {\n    \"naam\": \"<boolean>\",\n    \"korteNaam\": \"<boolean>\",\n    \"type\": \"<boolean>\",\n    \"status\": \"<boolean>\",\n    \"woonplaatsIdentificatie\": \"<boolean>\",\n    \"toelichting\": [\n     \"Openbare ruimtenaam komt mogelijk niet overeen met de vermelding in het straatnaambesluit.\",\n     \"Openbare ruimtenaam komt mogelijk niet overeen met de vermelding in het straatnaambesluit.\"\n    ]\n   },\n   \"_links\": {\n    \"self\": {\n     \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n     \"templated\": \"<boolean>\",\n     \"title\": \"<string>\"\n    },\n    \"woonplaats\": {\n     \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n     \"templated\": \"<boolean>\",\n     \"title\": \"<string>\"\n    }\n   }\n  },\n  \"nummeraanduiding\": {\n   \"identificatie\": \"<string>\",\n   \"domein\": \"<string>\",\n   \"huisnummer\": 1,\n   \"huisletter\": \"A\",\n   \"huisnummertoevoeging\": \"bis\",\n   \"postcode\": \"6922KZ\",\n   \"status\": \"<string>\",\n   \"geconstateerd\": \"<boolean>\",\n   \"documentdatum\": {},\n   \"documentnummer\": \"Duiven 25112019\",\n   \"woonplaatsIdentificatie\": \"2096\",\n   \"openbareRuimteIdentificatie\": \"0226300000136166\",\n   \"mogelijkOnjuist\": {\n    \"huisnummer\": \"<boolean>\",\n    \"huisletter\": \"<boolean>\",\n    \"huisnummertoevoeging\": \"<boolean>\",\n    \"postcode\": \"<boolean>\",\n    \"status\": \"<boolean>\",\n    \"woonplaatsIdentificatie\": \"<boolean>\",\n    \"openbareRuimteIdentificatie\": \"<boolean>\",\n    \"toelichting\": [\n     \"Woonplaats bestaat mogelijk niet.\",\n     \"Woonplaats bestaat mogelijk niet.\"\n    ]\n   },\n   \"_links\": {\n    \"self\": {\n     \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n     \"templated\": \"<boolean>\",\n     \"title\": \"<string>\"\n    },\n    \"adres\": {\n     \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n     \"templated\": \"<boolean>\",\n     \"title\": \"<string>\"\n    },\n    \"openbareRuimte\": {\n     \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n     \"templated\": \"<boolean>\",\n     \"title\": \"<string>\"\n    },\n    \"woonplaats\": {\n     \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n     \"templated\": \"<boolean>\",\n     \"title\": \"<string>\"\n    }\n   }\n  },\n  \"woonplaats\": {\n   \"identificatie\": \"<string>\",\n   \"domein\": \"<string>\",\n   \"naam\": \"Duiven\",\n   \"status\": \"<string>\",\n   \"geconstateerd\": \"<boolean>\",\n   \"documentdatum\": {},\n   \"documentnummer\": \"09.0898\",\n   \"mogelijkOnjuist\": {\n    \"naam\": \"<boolean>\",\n    \"geometrie\": \"<boolean>\",\n    \"status\": \"<boolean>\",\n    \"toelichting\": [\n     \"Woonplaats bestaat mogelijk niet.\",\n     \"Woonplaats bestaat mogelijk niet.\"\n    ]\n   },\n   \"_links\": {\n    \"self\": {\n     \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n     \"templated\": \"<boolean>\",\n     \"title\": \"<string>\"\n    }\n   }\n  }\n }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "73e61b8c-99b3-4a8b-95dd-bcd01a936516",
+                            "name": "Bad Request",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        ":nummeraanduidingidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "nummeraanduidingidentificatie"
+                                        }
+                                    ]
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request\",\n \"title\": \"Ten minste één parameter moet worden opgegeven.\",\n \"status\": 400,\n \"detail\": \"The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"paramsRequired\",\n \"invalidParams\": [\n  {\n   \"type\": \"https://www.vng.nl/realisatie/api/validaties/integer\",\n   \"name\": \"verblijfplaats__huisnummer\",\n   \"code\": \"integer\",\n   \"reason\": \"Waarde is geen geldige integer.\"\n  }\n ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "069bcb36-bf97-4e6c-9728-8b9a14493bda",
+                            "name": "Unauthorized",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        ":nummeraanduidingidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "nummeraanduidingidentificatie"
+                                        }
+                                    ]
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized\",\n \"title\": \"Niet correct geauthenticeerd.\",\n \"status\": 401,\n \"detail\": \"The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"authentication\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "e4a2d58a-4dc1-4715-aacb-56c1fae94abb",
+                            "name": "Forbidden",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        ":nummeraanduidingidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "nummeraanduidingidentificatie"
+                                        }
+                                    ]
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden\",\n \"title\": \"U bent niet geautoriseerd voor deze operatie.\",\n \"status\": 403,\n \"detail\": \"The server understood the request, but is refusing to fulfill it.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"autorisation\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "b07faeef-e72a-451c-b989-5750f2fc784e",
+                            "name": "Not Found",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        ":nummeraanduidingidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "nummeraanduidingidentificatie"
+                                        }
+                                    ]
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found\",\n \"title\": \"Opgevraagde resource bestaat niet.\",\n \"status\": 404,\n \"detail\": \"The server has not found anything matching the Request-URI.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notFound\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "a33bf563-f216-4320-899a-9d0033e3604e",
+                            "name": "Not Acceptable",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        ":nummeraanduidingidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "nummeraanduidingidentificatie"
+                                        }
+                                    ]
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Acceptable",
+                            "code": 406,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable\",\n \"title\": \"Gevraagde contenttype wordt niet ondersteund.\",\n \"status\": 406,\n \"detail\": \"The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAcceptable\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "305cfde1-bd5a-4bd9-bb23-d97cb571d7e4",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        ":nummeraanduidingidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "nummeraanduidingidentificatie"
+                                        }
+                                    ]
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error\",\n \"title\": \"Interne server fout.\",\n \"status\": 500,\n \"detail\": \"The server encountered an unexpected condition which prevented it from fulfilling the request.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"serverError\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "3b2698d0-930f-446a-b2da-84a38591e148",
+                            "name": "Service Unavailable",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        ":nummeraanduidingidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "nummeraanduidingidentificatie"
+                                        }
+                                    ]
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Service Unavailable",
+                            "code": 503,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable\",\n \"title\": \"Bronservice {bron} is tijdelijk niet beschikbaar.\",\n \"status\": 503,\n \"detail\": \"The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAvailable\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "3bc995da-2f49-461a-9ab3-6168727f8ccf",
+                            "name": "Er is een onverwachte fout opgetreden",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adressen",
+                                        ":nummeraanduidingidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "nummeraanduidingidentificatie"
+                                        }
+                                    ]
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"<uri>\",\n \"title\": \"<string>\",\n \"status\": \"<integer>\",\n \"detail\": \"<string>\",\n \"instance\": \"<uri>\",\n \"code\": \"<string>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": []
+                }
+            ],
+            "event": []
+        },
+        {
+            "id": "9f4b787c-1925-4b86-9755-49a1add0a49a",
+            "name": "adresseerbareobjecten",
+            "item": [
+                {
+                    "id": "c0829882-8b05-4e20-9d43-c37a2c678c37",
+                    "name": "vindt verblijfsobjecten, ligplaatsen, standplaatsen",
+                    "request": {
+                        "name": "vindt verblijfsobjecten, ligplaatsen, standplaatsen",
+                        "description": {
+                            "content": "Zoek actuele adresseerbaar objecten (verblijfsobjecten, standplaatsen of ligplaatsen) met een nummeraanduiding identificatie of pand identificatie. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature). Gebruik de expand parameter als je het antwoord wil uitbreiden met (delen van) de gerelateerde resources adres en pand, zie [functionele specificaties expand-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "adresseerbareobjecten"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "description": "Identificatie van een nummeraanduiding uit de BAG. Deze is 16 cijfers lang.",
+                                    "key": "nummeraanduidingIdentificatie",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "description": "Identificatie van een pand uit de BAG. Deze is 16 cijfers lang.",
+                                    "key": "pandIdentificatie",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "description": "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. In de definitie van het antwoord kun je bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+                                    "key": "expand",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "description": "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+                                    "key": "fields",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "description": "Pagina nummer",
+                                    "key": "page",
+                                    "value": "1"
+                                },
+                                {
+                                    "description": "",
+                                    "key": "pageSize",
+                                    "value": "20"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "X-Api-Key",
+                                "value": "",
+                                "description": "De API-key die je hebt gekregen dient bij elke request via de `X-Api-Key` request header meegestuurd te worden. Indien deze niet juist wordt meegestuurd, of het een ongeldige key betreft, zul je de foutmelding `403 Forbidden` terugkrijgen."
+                            },
+                            {
+                                "key": "Accept-Crs",
+                                "value": "<string>",
+                                "description": "Gewenste CRS van de coördinaten in de response."
+                            }
+                        ],
+                        "method": "GET",
+                        "auth": {
+                            "type": "noauth"
+                        }
+                    },
+                    "response": [
+                        {
+                            "id": "3f190486-ed64-4aea-91c6-0cedbcf87093",
+                            "name": "Geslaagd",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "nummeraanduidingIdentificatie",
+                                            "value": "0226200000038923"
+                                        },
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "warning",
+                                    "value": "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie hier de documentatie: https://omgevingswet.../api/.../v1\".",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Crs",
+                                    "value": "<string>",
+                                    "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/hal+json"
+                                }
+                            ],
+                            "body": "{\n \"_embedded\": {\n  \"adresseerbareObjecten\": [\n   {\n    \"identificatie\": \"0226010000038820\",\n    \"domein\": \"<string>\",\n    \"type\": \"<string>\",\n    \"documentdatum\": {},\n    \"documentnummer\": \"19SZ2048\",\n    \"gebruiksdoelen\": [\n     \"<string>\",\n     \"<string>\"\n    ],\n    \"geconstateerd\": \"<boolean>\",\n    \"geometrie\": {\n     \"punt\": {\n      \"coordinates\": [\n       \"<number>\",\n       \"<number>\"\n      ],\n      \"type\": \"<string>\"\n     },\n     \"vlak\": {\n      \"coordinates\": [\n       [\n        [\n         \"<number>\",\n         \"<number>\"\n        ],\n        [\n         \"<number>\",\n         \"<number>\"\n        ],\n        [\n         \"<number>\",\n         \"<number>\"\n        ],\n        [\n         \"<number>\",\n         \"<number>\"\n        ]\n       ],\n       [\n        [\n         \"<number>\",\n         \"<number>\"\n        ],\n        [\n         \"<number>\",\n         \"<number>\"\n        ],\n        [\n         \"<number>\",\n         \"<number>\"\n        ],\n        [\n         \"<number>\",\n         \"<number>\"\n        ]\n       ]\n      ],\n      \"type\": \"<string>\"\n     }\n    },\n    \"pandIdentificaties\": [\n     \"0226100000008856\",\n     \"0226100000008856\"\n    ],\n    \"nummeraanduidingIdentificaties\": [\n     {\n      \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n      \"isNevenadres\": \"<boolean>\"\n     },\n     {\n      \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n      \"isNevenadres\": \"<boolean>\"\n     }\n    ],\n    \"oppervlakte\": \"<integer>\",\n    \"status\": \"<string>\",\n    \"mogelijkOnjuist\": {\n     \"gebruiksdoelen\": \"<boolean>\",\n     \"geometrie\": \"<boolean>\",\n     \"nummeraanduidingIdentificaties\": \"<boolean>\",\n     \"pandIdentificaties\": \"<boolean>\",\n     \"oppervlakte\": \"<boolean>\",\n     \"status\": \"<boolean>\",\n     \"toelichting\": [\n      \"Locatie/contour mogelijk onjuist.\",\n      \"Locatie/contour mogelijk onjuist.\"\n     ]\n    },\n    \"_links\": {\n     \"adressen\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ],\n     \"panden\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ],\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     }\n    },\n    \"_embedded\": {\n     \"adressen\": [\n      {\n       \"straat\": \"Laan van de landinrichtingscommissie Duiven-Westervoort\",\n       \"huisnummer\": 1,\n       \"huisletter\": \"A\",\n       \"huisnummertoevoeging\": \"bis\",\n       \"postcode\": \"6922KZ\",\n       \"woonplaats\": \"Duiven\",\n       \"korteNaam\": \"Ln vd l D-Westervoort\",\n       \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n       \"openbareRuimteIdentificatie\": \"0226300000136166\",\n       \"woonplaatsIdentificatie\": \"2096\",\n       \"adresseerbaarObjectIdentificatie\": \"0226010000038820\",\n       \"pandIdentificaties\": [\n        \"0226100000008856\",\n        \"0226100000008856\"\n       ],\n       \"isNevenadres\": \"<boolean>\",\n       \"geconstateerd\": \"<boolean>\",\n       \"mogelijkOnjuist\": {\n        \"korteNaam\": \"<boolean>\",\n        \"straat\": \"<boolean>\",\n        \"huisnummer\": \"<boolean>\",\n        \"huisletter\": \"<boolean>\",\n        \"huisnummertoevoeging\": \"<boolean>\",\n        \"postcode\": \"<boolean>\",\n        \"woonplaats\": \"<boolean>\",\n        \"nummeraanduidingIdentificatie\": \"<boolean>\",\n        \"openbareRuimteIdentificatie\": \"<boolean>\",\n        \"woonplaatsIdentificatie\": \"<boolean>\",\n        \"toelichting\": [\n         \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\",\n         \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\"\n        ]\n       },\n       \"_links\": {\n        \"self\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"openbareRuimte\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"nummeraanduiding\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"woonplaats\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"adresseerbaarObject\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"panden\": [\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         },\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         }\n        ]\n       }\n      },\n      {\n       \"straat\": \"Laan van de landinrichtingscommissie Duiven-Westervoort\",\n       \"huisnummer\": 1,\n       \"huisletter\": \"A\",\n       \"huisnummertoevoeging\": \"bis\",\n       \"postcode\": \"6922KZ\",\n       \"woonplaats\": \"Duiven\",\n       \"korteNaam\": \"Ln vd l D-Westervoort\",\n       \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n       \"openbareRuimteIdentificatie\": \"0226300000136166\",\n       \"woonplaatsIdentificatie\": \"2096\",\n       \"adresseerbaarObjectIdentificatie\": \"0226010000038820\",\n       \"pandIdentificaties\": [\n        \"0226100000008856\",\n        \"0226100000008856\"\n       ],\n       \"isNevenadres\": \"<boolean>\",\n       \"geconstateerd\": \"<boolean>\",\n       \"mogelijkOnjuist\": {\n        \"korteNaam\": \"<boolean>\",\n        \"straat\": \"<boolean>\",\n        \"huisnummer\": \"<boolean>\",\n        \"huisletter\": \"<boolean>\",\n        \"huisnummertoevoeging\": \"<boolean>\",\n        \"postcode\": \"<boolean>\",\n        \"woonplaats\": \"<boolean>\",\n        \"nummeraanduidingIdentificatie\": \"<boolean>\",\n        \"openbareRuimteIdentificatie\": \"<boolean>\",\n        \"woonplaatsIdentificatie\": \"<boolean>\",\n        \"toelichting\": [\n         \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\",\n         \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\"\n        ]\n       },\n       \"_links\": {\n        \"self\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"openbareRuimte\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"nummeraanduiding\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"woonplaats\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"adresseerbaarObject\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"panden\": [\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         },\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         }\n        ]\n       }\n      }\n     ],\n     \"panden\": [\n      {\n       \"identificatie\": \"<string>\",\n       \"domein\": \"<string>\",\n       \"geometrie\": {\n        \"coordinates\": [\n         [\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ]\n         ],\n         [\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ]\n         ]\n        ],\n        \"type\": \"<string>\"\n       },\n       \"oorspronkelijkBouwjaar\": 1991,\n       \"status\": \"<string>\",\n       \"geconstateerd\": \"<boolean>\",\n       \"documentdatum\": {},\n       \"documentnummer\": \"09.BW.0273\",\n       \"adresseerbaarObjectIdentificaties\": [\n        \"0226010000038820\",\n        \"0226010000038820\"\n       ],\n       \"nummeraanduidingIdentificaties\": [\n        {\n         \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n         \"isNevenadres\": \"<boolean>\"\n        },\n        {\n         \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n         \"isNevenadres\": \"<boolean>\"\n        }\n       ],\n       \"mogelijkOnjuist\": {\n        \"geometrie\": \"<boolean>\",\n        \"oorspronkelijkBouwjaar\": \"<boolean>\",\n        \"status\": \"<boolean>\",\n        \"toelichting\": [\n         \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\",\n         \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\"\n        ]\n       },\n       \"_links\": {\n        \"self\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"adressen\": [\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         },\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         }\n        ],\n        \"adresseerbareObjecten\": [\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         },\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         }\n        ]\n       }\n      },\n      {\n       \"identificatie\": \"<string>\",\n       \"domein\": \"<string>\",\n       \"geometrie\": {\n        \"coordinates\": [\n         [\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ]\n         ],\n         [\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ]\n         ]\n        ],\n        \"type\": \"<string>\"\n       },\n       \"oorspronkelijkBouwjaar\": 1991,\n       \"status\": \"<string>\",\n       \"geconstateerd\": \"<boolean>\",\n       \"documentdatum\": {},\n       \"documentnummer\": \"09.BW.0273\",\n       \"adresseerbaarObjectIdentificaties\": [\n        \"0226010000038820\",\n        \"0226010000038820\"\n       ],\n       \"nummeraanduidingIdentificaties\": [\n        {\n         \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n         \"isNevenadres\": \"<boolean>\"\n        },\n        {\n         \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n         \"isNevenadres\": \"<boolean>\"\n        }\n       ],\n       \"mogelijkOnjuist\": {\n        \"geometrie\": \"<boolean>\",\n        \"oorspronkelijkBouwjaar\": \"<boolean>\",\n        \"status\": \"<boolean>\",\n        \"toelichting\": [\n         \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\",\n         \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\"\n        ]\n       },\n       \"_links\": {\n        \"self\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"adressen\": [\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         },\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         }\n        ],\n        \"adresseerbareObjecten\": [\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         },\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         }\n        ]\n       }\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"0226010000038820\",\n    \"domein\": \"<string>\",\n    \"type\": \"<string>\",\n    \"documentdatum\": {},\n    \"documentnummer\": \"19SZ2048\",\n    \"gebruiksdoelen\": [\n     \"<string>\",\n     \"<string>\"\n    ],\n    \"geconstateerd\": \"<boolean>\",\n    \"geometrie\": {\n     \"punt\": {\n      \"coordinates\": [\n       \"<number>\",\n       \"<number>\"\n      ],\n      \"type\": \"<string>\"\n     },\n     \"vlak\": {\n      \"coordinates\": [\n       [\n        [\n         \"<number>\",\n         \"<number>\"\n        ],\n        [\n         \"<number>\",\n         \"<number>\"\n        ],\n        [\n         \"<number>\",\n         \"<number>\"\n        ],\n        [\n         \"<number>\",\n         \"<number>\"\n        ]\n       ],\n       [\n        [\n         \"<number>\",\n         \"<number>\"\n        ],\n        [\n         \"<number>\",\n         \"<number>\"\n        ],\n        [\n         \"<number>\",\n         \"<number>\"\n        ],\n        [\n         \"<number>\",\n         \"<number>\"\n        ]\n       ]\n      ],\n      \"type\": \"<string>\"\n     }\n    },\n    \"pandIdentificaties\": [\n     \"0226100000008856\",\n     \"0226100000008856\"\n    ],\n    \"nummeraanduidingIdentificaties\": [\n     {\n      \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n      \"isNevenadres\": \"<boolean>\"\n     },\n     {\n      \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n      \"isNevenadres\": \"<boolean>\"\n     }\n    ],\n    \"oppervlakte\": \"<integer>\",\n    \"status\": \"<string>\",\n    \"mogelijkOnjuist\": {\n     \"gebruiksdoelen\": \"<boolean>\",\n     \"geometrie\": \"<boolean>\",\n     \"nummeraanduidingIdentificaties\": \"<boolean>\",\n     \"pandIdentificaties\": \"<boolean>\",\n     \"oppervlakte\": \"<boolean>\",\n     \"status\": \"<boolean>\",\n     \"toelichting\": [\n      \"Locatie/contour mogelijk onjuist.\",\n      \"Locatie/contour mogelijk onjuist.\"\n     ]\n    },\n    \"_links\": {\n     \"adressen\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ],\n     \"panden\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ],\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     }\n    },\n    \"_embedded\": {\n     \"adressen\": [\n      {\n       \"straat\": \"Laan van de landinrichtingscommissie Duiven-Westervoort\",\n       \"huisnummer\": 1,\n       \"huisletter\": \"A\",\n       \"huisnummertoevoeging\": \"bis\",\n       \"postcode\": \"6922KZ\",\n       \"woonplaats\": \"Duiven\",\n       \"korteNaam\": \"Ln vd l D-Westervoort\",\n       \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n       \"openbareRuimteIdentificatie\": \"0226300000136166\",\n       \"woonplaatsIdentificatie\": \"2096\",\n       \"adresseerbaarObjectIdentificatie\": \"0226010000038820\",\n       \"pandIdentificaties\": [\n        \"0226100000008856\",\n        \"0226100000008856\"\n       ],\n       \"isNevenadres\": \"<boolean>\",\n       \"geconstateerd\": \"<boolean>\",\n       \"mogelijkOnjuist\": {\n        \"korteNaam\": \"<boolean>\",\n        \"straat\": \"<boolean>\",\n        \"huisnummer\": \"<boolean>\",\n        \"huisletter\": \"<boolean>\",\n        \"huisnummertoevoeging\": \"<boolean>\",\n        \"postcode\": \"<boolean>\",\n        \"woonplaats\": \"<boolean>\",\n        \"nummeraanduidingIdentificatie\": \"<boolean>\",\n        \"openbareRuimteIdentificatie\": \"<boolean>\",\n        \"woonplaatsIdentificatie\": \"<boolean>\",\n        \"toelichting\": [\n         \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\",\n         \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\"\n        ]\n       },\n       \"_links\": {\n        \"self\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"openbareRuimte\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"nummeraanduiding\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"woonplaats\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"adresseerbaarObject\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"panden\": [\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         },\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         }\n        ]\n       }\n      },\n      {\n       \"straat\": \"Laan van de landinrichtingscommissie Duiven-Westervoort\",\n       \"huisnummer\": 1,\n       \"huisletter\": \"A\",\n       \"huisnummertoevoeging\": \"bis\",\n       \"postcode\": \"6922KZ\",\n       \"woonplaats\": \"Duiven\",\n       \"korteNaam\": \"Ln vd l D-Westervoort\",\n       \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n       \"openbareRuimteIdentificatie\": \"0226300000136166\",\n       \"woonplaatsIdentificatie\": \"2096\",\n       \"adresseerbaarObjectIdentificatie\": \"0226010000038820\",\n       \"pandIdentificaties\": [\n        \"0226100000008856\",\n        \"0226100000008856\"\n       ],\n       \"isNevenadres\": \"<boolean>\",\n       \"geconstateerd\": \"<boolean>\",\n       \"mogelijkOnjuist\": {\n        \"korteNaam\": \"<boolean>\",\n        \"straat\": \"<boolean>\",\n        \"huisnummer\": \"<boolean>\",\n        \"huisletter\": \"<boolean>\",\n        \"huisnummertoevoeging\": \"<boolean>\",\n        \"postcode\": \"<boolean>\",\n        \"woonplaats\": \"<boolean>\",\n        \"nummeraanduidingIdentificatie\": \"<boolean>\",\n        \"openbareRuimteIdentificatie\": \"<boolean>\",\n        \"woonplaatsIdentificatie\": \"<boolean>\",\n        \"toelichting\": [\n         \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\",\n         \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\"\n        ]\n       },\n       \"_links\": {\n        \"self\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"openbareRuimte\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"nummeraanduiding\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"woonplaats\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"adresseerbaarObject\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"panden\": [\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         },\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         }\n        ]\n       }\n      }\n     ],\n     \"panden\": [\n      {\n       \"identificatie\": \"<string>\",\n       \"domein\": \"<string>\",\n       \"geometrie\": {\n        \"coordinates\": [\n         [\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ]\n         ],\n         [\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ]\n         ]\n        ],\n        \"type\": \"<string>\"\n       },\n       \"oorspronkelijkBouwjaar\": 1991,\n       \"status\": \"<string>\",\n       \"geconstateerd\": \"<boolean>\",\n       \"documentdatum\": {},\n       \"documentnummer\": \"09.BW.0273\",\n       \"adresseerbaarObjectIdentificaties\": [\n        \"0226010000038820\",\n        \"0226010000038820\"\n       ],\n       \"nummeraanduidingIdentificaties\": [\n        {\n         \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n         \"isNevenadres\": \"<boolean>\"\n        },\n        {\n         \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n         \"isNevenadres\": \"<boolean>\"\n        }\n       ],\n       \"mogelijkOnjuist\": {\n        \"geometrie\": \"<boolean>\",\n        \"oorspronkelijkBouwjaar\": \"<boolean>\",\n        \"status\": \"<boolean>\",\n        \"toelichting\": [\n         \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\",\n         \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\"\n        ]\n       },\n       \"_links\": {\n        \"self\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"adressen\": [\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         },\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         }\n        ],\n        \"adresseerbareObjecten\": [\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         },\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         }\n        ]\n       }\n      },\n      {\n       \"identificatie\": \"<string>\",\n       \"domein\": \"<string>\",\n       \"geometrie\": {\n        \"coordinates\": [\n         [\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ]\n         ],\n         [\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ],\n          [\n           \"<number>\",\n           \"<number>\"\n          ]\n         ]\n        ],\n        \"type\": \"<string>\"\n       },\n       \"oorspronkelijkBouwjaar\": 1991,\n       \"status\": \"<string>\",\n       \"geconstateerd\": \"<boolean>\",\n       \"documentdatum\": {},\n       \"documentnummer\": \"09.BW.0273\",\n       \"adresseerbaarObjectIdentificaties\": [\n        \"0226010000038820\",\n        \"0226010000038820\"\n       ],\n       \"nummeraanduidingIdentificaties\": [\n        {\n         \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n         \"isNevenadres\": \"<boolean>\"\n        },\n        {\n         \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n         \"isNevenadres\": \"<boolean>\"\n        }\n       ],\n       \"mogelijkOnjuist\": {\n        \"geometrie\": \"<boolean>\",\n        \"oorspronkelijkBouwjaar\": \"<boolean>\",\n        \"status\": \"<boolean>\",\n        \"toelichting\": [\n         \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\",\n         \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\"\n        ]\n       },\n       \"_links\": {\n        \"self\": {\n         \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n         \"templated\": \"<boolean>\",\n         \"title\": \"<string>\"\n        },\n        \"adressen\": [\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         },\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         }\n        ],\n        \"adresseerbareObjecten\": [\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         },\n         {\n          \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n          \"templated\": \"<boolean>\",\n          \"title\": \"<string>\"\n         }\n        ]\n       }\n      }\n     ]\n    }\n   }\n  ]\n },\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  },\n  \"first\": {\n   \"href\": \"/resourcenaam?page=1\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"Eerste pagina\"\n  },\n  \"previous\": {\n   \"href\": \"/resourcenaam?page=3\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"Vorige pagina\"\n  },\n  \"next\": {\n   \"href\": \"/resourcenaam?page=5\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"Volgende pagina\"\n  },\n  \"last\": {\n   \"href\": \"/resourcenaam?page=8\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"Laatste pagina\"\n  }\n }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "dc099c9c-e16a-479d-9727-5bac3dc9a6c7",
+                            "name": "Bad Request",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "nummeraanduidingIdentificatie",
+                                            "value": "0226200000038923"
+                                        },
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request\",\n \"title\": \"Ten minste één parameter moet worden opgegeven.\",\n \"status\": 400,\n \"detail\": \"The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"paramsRequired\",\n \"invalidParams\": [\n  {\n   \"type\": \"https://www.vng.nl/realisatie/api/validaties/integer\",\n   \"name\": \"verblijfplaats__huisnummer\",\n   \"code\": \"integer\",\n   \"reason\": \"Waarde is geen geldige integer.\"\n  }\n ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "19a94374-cf74-462f-8cf7-52aac05dbee1",
+                            "name": "Unauthorized",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "nummeraanduidingIdentificatie",
+                                            "value": "0226200000038923"
+                                        },
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized\",\n \"title\": \"Niet correct geauthenticeerd.\",\n \"status\": 401,\n \"detail\": \"The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"authentication\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "51175401-6627-4b25-b4b9-591601b7a190",
+                            "name": "Forbidden",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "nummeraanduidingIdentificatie",
+                                            "value": "0226200000038923"
+                                        },
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden\",\n \"title\": \"U bent niet geautoriseerd voor deze operatie.\",\n \"status\": 403,\n \"detail\": \"The server understood the request, but is refusing to fulfill it.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"autorisation\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "d7cdd2dd-284d-45e7-aa09-af8a02943f42",
+                            "name": "Not Acceptable",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "nummeraanduidingIdentificatie",
+                                            "value": "0226200000038923"
+                                        },
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Acceptable",
+                            "code": 406,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable\",\n \"title\": \"Gevraagde contenttype wordt niet ondersteund.\",\n \"status\": 406,\n \"detail\": \"The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAcceptable\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "212b21ac-8766-4971-bd85-7ab1f0d7f41e",
+                            "name": "Precondition failed",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "nummeraanduidingIdentificatie",
+                                            "value": "0226200000038923"
+                                        },
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Precondition Failed",
+                            "code": 412,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.13 412 Precondition Failed\",\n \"title\": \"Precondition Failed\",\n \"status\": 412,\n \"detail\": \"The precondition given in one or more of the request-header fields evaluated to false when it was tested on the server.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"preconditionFailed\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "a09da416-37ab-4be0-a548-54c1f8590572",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "nummeraanduidingIdentificatie",
+                                            "value": "0226200000038923"
+                                        },
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error\",\n \"title\": \"Interne server fout.\",\n \"status\": 500,\n \"detail\": \"The server encountered an unexpected condition which prevented it from fulfilling the request.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"serverError\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "de6e210d-eff8-4108-bacb-1fd53487dd76",
+                            "name": "Service Unavailable",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "nummeraanduidingIdentificatie",
+                                            "value": "0226200000038923"
+                                        },
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Service Unavailable",
+                            "code": 503,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable\",\n \"title\": \"Bronservice {bron} is tijdelijk niet beschikbaar.\",\n \"status\": 503,\n \"detail\": \"The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAvailable\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "6942509e-d03b-43f1-80b3-f1924ed72763",
+                            "name": "Er is een onverwachte fout opgetreden",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "nummeraanduidingIdentificatie",
+                                            "value": "0226200000038923"
+                                        },
+                                        {
+                                            "key": "pandIdentificatie",
+                                            "value": "0226100000008856"
+                                        },
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "page",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "key": "pageSize",
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"<uri>\",\n \"title\": \"<string>\",\n \"status\": \"<integer>\",\n \"detail\": \"<string>\",\n \"instance\": \"<uri>\",\n \"code\": \"<string>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": []
+                },
+                {
+                    "id": "22357cec-fd77-4a1d-8d35-d976b5730885",
+                    "name": "levert een verblijfsobject, standplaats of ligplaats",
+                    "request": {
+                        "name": "levert een verblijfsobject, standplaats of ligplaats",
+                        "description": {
+                            "content": "Raadpleeg een actueel adresseerbaar object met de identificatie. Dit is de identificatie van een verblijfsobject, ligplaats of standplaats. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature). Gebruik de expand parameter als je het antwoord wil uitbreiden met (delen van) de gerelateerde resources adres en pand, zie [functionele specificaties expand-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "adresseerbareobjecten",
+                                ":adresseerbaarobjectidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "description": "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. In de definitie van het antwoord kun je bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+                                    "key": "expand",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "description": "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "description": "(Required) De identificatie van een adresserbaar object uit de BAG. Dit kan een verblijfsobject, een standplaats of een ligplaats zijn.",
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "adresseerbaarobjectidentificatie"
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "X-Api-Key",
+                                "value": "",
+                                "description": "De API-key die je hebt gekregen dient bij elke request via de `X-Api-Key` request header meegestuurd te worden. Indien deze niet juist wordt meegestuurd, of het een ongeldige key betreft, zul je de foutmelding `403 Forbidden` terugkrijgen."
+                            },
+                            {
+                                "key": "Accept-Crs",
+                                "value": "<string>",
+                                "description": "Gewenste CRS van de coördinaten in de response."
+                            }
+                        ],
+                        "method": "GET",
+                        "auth": {
+                            "type": "noauth"
+                        }
+                    },
+                    "response": [
+                        {
+                            "id": "4a2b8197-b0da-491d-a173-9ef65c9ff95c",
+                            "name": "Geslaagd",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten",
+                                        ":adresseerbaarobjectidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "adresseerbaarobjectidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "warning",
+                                    "value": "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie hier de documentatie: https://omgevingswet.../api/.../v1\".",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Crs",
+                                    "value": "<string>",
+                                    "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/hal+json"
+                                }
+                            ],
+                            "body": "{\n \"identificatie\": \"0226010000038820\",\n \"domein\": \"<string>\",\n \"type\": \"<string>\",\n \"documentdatum\": {},\n \"documentnummer\": \"19SZ2048\",\n \"gebruiksdoelen\": [\n  \"<string>\",\n  \"<string>\"\n ],\n \"geconstateerd\": \"<boolean>\",\n \"geometrie\": {\n  \"punt\": {\n   \"coordinates\": [\n    \"<number>\",\n    \"<number>\"\n   ],\n   \"type\": \"<string>\"\n  },\n  \"vlak\": {\n   \"coordinates\": [\n    [\n     [\n      \"<number>\",\n      \"<number>\"\n     ],\n     [\n      \"<number>\",\n      \"<number>\"\n     ],\n     [\n      \"<number>\",\n      \"<number>\"\n     ],\n     [\n      \"<number>\",\n      \"<number>\"\n     ]\n    ],\n    [\n     [\n      \"<number>\",\n      \"<number>\"\n     ],\n     [\n      \"<number>\",\n      \"<number>\"\n     ],\n     [\n      \"<number>\",\n      \"<number>\"\n     ],\n     [\n      \"<number>\",\n      \"<number>\"\n     ]\n    ]\n   ],\n   \"type\": \"<string>\"\n  }\n },\n \"pandIdentificaties\": [\n  \"0226100000008856\",\n  \"0226100000008856\"\n ],\n \"nummeraanduidingIdentificaties\": [\n  {\n   \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n   \"isNevenadres\": \"<boolean>\"\n  },\n  {\n   \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n   \"isNevenadres\": \"<boolean>\"\n  }\n ],\n \"oppervlakte\": \"<integer>\",\n \"status\": \"<string>\",\n \"mogelijkOnjuist\": {\n  \"gebruiksdoelen\": \"<boolean>\",\n  \"geometrie\": \"<boolean>\",\n  \"nummeraanduidingIdentificaties\": \"<boolean>\",\n  \"pandIdentificaties\": \"<boolean>\",\n  \"oppervlakte\": \"<boolean>\",\n  \"status\": \"<boolean>\",\n  \"toelichting\": [\n   \"Locatie/contour mogelijk onjuist.\",\n   \"Locatie/contour mogelijk onjuist.\"\n  ]\n },\n \"_links\": {\n  \"adressen\": [\n   {\n    \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n    \"templated\": \"<boolean>\",\n    \"title\": \"<string>\"\n   },\n   {\n    \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n    \"templated\": \"<boolean>\",\n    \"title\": \"<string>\"\n   }\n  ],\n  \"panden\": [\n   {\n    \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n    \"templated\": \"<boolean>\",\n    \"title\": \"<string>\"\n   },\n   {\n    \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n    \"templated\": \"<boolean>\",\n    \"title\": \"<string>\"\n   }\n  ],\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  }\n },\n \"_embedded\": {\n  \"adressen\": [\n   {\n    \"straat\": \"Laan van de landinrichtingscommissie Duiven-Westervoort\",\n    \"huisnummer\": 1,\n    \"huisletter\": \"A\",\n    \"huisnummertoevoeging\": \"bis\",\n    \"postcode\": \"6922KZ\",\n    \"woonplaats\": \"Duiven\",\n    \"korteNaam\": \"Ln vd l D-Westervoort\",\n    \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n    \"openbareRuimteIdentificatie\": \"0226300000136166\",\n    \"woonplaatsIdentificatie\": \"2096\",\n    \"adresseerbaarObjectIdentificatie\": \"0226010000038820\",\n    \"pandIdentificaties\": [\n     \"0226100000008856\",\n     \"0226100000008856\"\n    ],\n    \"isNevenadres\": \"<boolean>\",\n    \"geconstateerd\": \"<boolean>\",\n    \"mogelijkOnjuist\": {\n     \"korteNaam\": \"<boolean>\",\n     \"straat\": \"<boolean>\",\n     \"huisnummer\": \"<boolean>\",\n     \"huisletter\": \"<boolean>\",\n     \"huisnummertoevoeging\": \"<boolean>\",\n     \"postcode\": \"<boolean>\",\n     \"woonplaats\": \"<boolean>\",\n     \"nummeraanduidingIdentificatie\": \"<boolean>\",\n     \"openbareRuimteIdentificatie\": \"<boolean>\",\n     \"woonplaatsIdentificatie\": \"<boolean>\",\n     \"toelichting\": [\n      \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\",\n      \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\"\n     ]\n    },\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"openbareRuimte\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"nummeraanduiding\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"woonplaats\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"adresseerbaarObject\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"panden\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ]\n    }\n   },\n   {\n    \"straat\": \"Laan van de landinrichtingscommissie Duiven-Westervoort\",\n    \"huisnummer\": 1,\n    \"huisletter\": \"A\",\n    \"huisnummertoevoeging\": \"bis\",\n    \"postcode\": \"6922KZ\",\n    \"woonplaats\": \"Duiven\",\n    \"korteNaam\": \"Ln vd l D-Westervoort\",\n    \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n    \"openbareRuimteIdentificatie\": \"0226300000136166\",\n    \"woonplaatsIdentificatie\": \"2096\",\n    \"adresseerbaarObjectIdentificatie\": \"0226010000038820\",\n    \"pandIdentificaties\": [\n     \"0226100000008856\",\n     \"0226100000008856\"\n    ],\n    \"isNevenadres\": \"<boolean>\",\n    \"geconstateerd\": \"<boolean>\",\n    \"mogelijkOnjuist\": {\n     \"korteNaam\": \"<boolean>\",\n     \"straat\": \"<boolean>\",\n     \"huisnummer\": \"<boolean>\",\n     \"huisletter\": \"<boolean>\",\n     \"huisnummertoevoeging\": \"<boolean>\",\n     \"postcode\": \"<boolean>\",\n     \"woonplaats\": \"<boolean>\",\n     \"nummeraanduidingIdentificatie\": \"<boolean>\",\n     \"openbareRuimteIdentificatie\": \"<boolean>\",\n     \"woonplaatsIdentificatie\": \"<boolean>\",\n     \"toelichting\": [\n      \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\",\n      \"Geometrie of woonplaatsgrens is mogelijk onjuist, waardoor gaten of overlappingen ontstaan in de registratie van woonplaatsen. Gevolg kan zijn dat een object in een verkeerde woonplaats, in twee woonplaatsen, of in geen enkele woonplaats ligt.\"\n     ]\n    },\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"openbareRuimte\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"nummeraanduiding\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"woonplaats\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"adresseerbaarObject\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"panden\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ]\n    }\n   }\n  ],\n  \"panden\": [\n   {\n    \"identificatie\": \"<string>\",\n    \"domein\": \"<string>\",\n    \"geometrie\": {\n     \"coordinates\": [\n      [\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ]\n      ],\n      [\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ]\n      ]\n     ],\n     \"type\": \"<string>\"\n    },\n    \"oorspronkelijkBouwjaar\": 1991,\n    \"status\": \"<string>\",\n    \"geconstateerd\": \"<boolean>\",\n    \"documentdatum\": {},\n    \"documentnummer\": \"09.BW.0273\",\n    \"adresseerbaarObjectIdentificaties\": [\n     \"0226010000038820\",\n     \"0226010000038820\"\n    ],\n    \"nummeraanduidingIdentificaties\": [\n     {\n      \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n      \"isNevenadres\": \"<boolean>\"\n     },\n     {\n      \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n      \"isNevenadres\": \"<boolean>\"\n     }\n    ],\n    \"mogelijkOnjuist\": {\n     \"geometrie\": \"<boolean>\",\n     \"oorspronkelijkBouwjaar\": \"<boolean>\",\n     \"status\": \"<boolean>\",\n     \"toelichting\": [\n      \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\",\n      \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\"\n     ]\n    },\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"adressen\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ],\n     \"adresseerbareObjecten\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"<string>\",\n    \"domein\": \"<string>\",\n    \"geometrie\": {\n     \"coordinates\": [\n      [\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ]\n      ],\n      [\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ]\n      ]\n     ],\n     \"type\": \"<string>\"\n    },\n    \"oorspronkelijkBouwjaar\": 1991,\n    \"status\": \"<string>\",\n    \"geconstateerd\": \"<boolean>\",\n    \"documentdatum\": {},\n    \"documentnummer\": \"09.BW.0273\",\n    \"adresseerbaarObjectIdentificaties\": [\n     \"0226010000038820\",\n     \"0226010000038820\"\n    ],\n    \"nummeraanduidingIdentificaties\": [\n     {\n      \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n      \"isNevenadres\": \"<boolean>\"\n     },\n     {\n      \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n      \"isNevenadres\": \"<boolean>\"\n     }\n    ],\n    \"mogelijkOnjuist\": {\n     \"geometrie\": \"<boolean>\",\n     \"oorspronkelijkBouwjaar\": \"<boolean>\",\n     \"status\": \"<boolean>\",\n     \"toelichting\": [\n      \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\",\n      \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\"\n     ]\n    },\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"adressen\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ],\n     \"adresseerbareObjecten\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "fbc895fc-ea7b-4cbf-81ee-a6cae4ea1163",
+                            "name": "Bad Request",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten",
+                                        ":adresseerbaarobjectidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "adresseerbaarobjectidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request\",\n \"title\": \"Ten minste één parameter moet worden opgegeven.\",\n \"status\": 400,\n \"detail\": \"The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"paramsRequired\",\n \"invalidParams\": [\n  {\n   \"type\": \"https://www.vng.nl/realisatie/api/validaties/integer\",\n   \"name\": \"verblijfplaats__huisnummer\",\n   \"code\": \"integer\",\n   \"reason\": \"Waarde is geen geldige integer.\"\n  }\n ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "0723f309-c59b-45c4-941a-aed1df1b221b",
+                            "name": "Unauthorized",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten",
+                                        ":adresseerbaarobjectidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "adresseerbaarobjectidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized\",\n \"title\": \"Niet correct geauthenticeerd.\",\n \"status\": 401,\n \"detail\": \"The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"authentication\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "98b16aae-d6af-4f35-b464-71563222f518",
+                            "name": "Forbidden",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten",
+                                        ":adresseerbaarobjectidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "adresseerbaarobjectidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden\",\n \"title\": \"U bent niet geautoriseerd voor deze operatie.\",\n \"status\": 403,\n \"detail\": \"The server understood the request, but is refusing to fulfill it.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"autorisation\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "142f4146-1743-47a4-a0cd-c9b55ddf5c66",
+                            "name": "Not Found",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten",
+                                        ":adresseerbaarobjectidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "adresseerbaarobjectidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found\",\n \"title\": \"Opgevraagde resource bestaat niet.\",\n \"status\": 404,\n \"detail\": \"The server has not found anything matching the Request-URI.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notFound\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "085e2f3f-21ce-41e8-8559-e85c096f55fe",
+                            "name": "Not Acceptable",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten",
+                                        ":adresseerbaarobjectidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "adresseerbaarobjectidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Acceptable",
+                            "code": 406,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable\",\n \"title\": \"Gevraagde contenttype wordt niet ondersteund.\",\n \"status\": 406,\n \"detail\": \"The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAcceptable\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "df8e12b9-0be2-4fbe-817a-57912ce30853",
+                            "name": "Precondition failed",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten",
+                                        ":adresseerbaarobjectidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "adresseerbaarobjectidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Precondition Failed",
+                            "code": 412,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.13 412 Precondition Failed\",\n \"title\": \"Precondition Failed\",\n \"status\": 412,\n \"detail\": \"The precondition given in one or more of the request-header fields evaluated to false when it was tested on the server.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"preconditionFailed\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "f8db2824-1d9c-4c00-9248-9989e9116ef5",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten",
+                                        ":adresseerbaarobjectidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "adresseerbaarobjectidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error\",\n \"title\": \"Interne server fout.\",\n \"status\": 500,\n \"detail\": \"The server encountered an unexpected condition which prevented it from fulfilling the request.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"serverError\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "721faec2-3390-4f59-aff0-a9c0358e44eb",
+                            "name": "Service Unavailable",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten",
+                                        ":adresseerbaarobjectidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "adresseerbaarobjectidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Service Unavailable",
+                            "code": 503,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable\",\n \"title\": \"Bronservice {bron} is tijdelijk niet beschikbaar.\",\n \"status\": 503,\n \"detail\": \"The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAvailable\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "43ea30e1-3181-42dc-a6e2-63c5d3f9e2a5",
+                            "name": "Er is een onverwachte fout opgetreden",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "adresseerbareobjecten",
+                                        ":adresseerbaarobjectidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "expand",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "adresseerbaarobjectidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"<uri>\",\n \"title\": \"<string>\",\n \"status\": \"<integer>\",\n \"detail\": \"<string>\",\n \"instance\": \"<uri>\",\n \"code\": \"<string>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": []
+                }
+            ],
+            "event": []
+        },
+        {
+            "id": "717aeee0-b72d-40d0-9394-8d1969d3e6e4",
+            "name": "levert BAG details van een woonplaats",
+            "request": {
+                "name": "levert BAG details van een woonplaats",
+                "description": {
+                    "content": "Raadpleeg een actuele woonplaats met de identificatie. Een woonplaats is een gedeelte van het grondgebied van de gemeente met een naam. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature). Gebruik de expand parameter als je het antwoord wil uitbreiden met de gerelateerde resource geometrie, zie [functionele specificaties expand-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "woonplaatsen",
+                        ":woonplaatsidentificatie"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [
+                        {
+                            "description": "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. In de definitie van het antwoord kun je bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature).",
+                            "key": "expand",
+                            "value": "<string>"
+                        },
+                        {
+                            "description": "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+                            "key": "fields",
+                            "value": "<string>"
+                        }
+                    ],
+                    "variable": [
+                        {
+                            "description": "(Required) Identificatie van een object uit de BAG. Deze is 4 lang bij een woonplaats en 16 lang bij de andere objecten.",
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "woonplaatsidentificatie"
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "X-Api-Key",
+                        "value": "",
+                        "description": "De API-key die je hebt gekregen dient bij elke request via de `X-Api-Key` request header meegestuurd te worden. Indien deze niet juist wordt meegestuurd, of het een ongeldige key betreft, zul je de foutmelding `403 Forbidden` terugkrijgen."
+                    },
+                    {
+                        "key": "Accept-Crs",
+                        "value": "<string>",
+                        "description": "Gewenste CRS van de coördinaten in de response."
+                    }
+                ],
+                "method": "GET",
+                "auth": {
+                    "type": "noauth"
+                }
+            },
+            "response": [
+                {
+                    "id": "0e5ccff5-930a-4576-8bd2-962fff8d48aa",
+                    "name": "Geslaagd",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "woonplaatsen",
+                                ":woonplaatsidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "expand",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "woonplaatsidentificatie"
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "Accept-Crs",
+                                "value": "<string>",
+                                "description": "Gewenste CRS van de coördinaten in de response."
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "warning",
+                            "value": "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie hier de documentatie: https://omgevingswet.../api/.../v1\".",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Crs",
+                            "value": "<string>",
+                            "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/hal+json"
+                        }
+                    ],
+                    "body": "{\n \"identificatie\": \"<string>\",\n \"domein\": \"<string>\",\n \"naam\": \"Duiven\",\n \"status\": \"<string>\",\n \"geconstateerd\": \"<boolean>\",\n \"documentdatum\": {},\n \"documentnummer\": \"09.0898\",\n \"mogelijkOnjuist\": {\n  \"naam\": \"<boolean>\",\n  \"geometrie\": \"<boolean>\",\n  \"status\": \"<boolean>\",\n  \"toelichting\": [\n   \"Woonplaats bestaat mogelijk niet.\",\n   \"Woonplaats bestaat mogelijk niet.\"\n  ]\n },\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  }\n },\n \"_embedded\": {\n  \"geometrie\": {\n   \"vlak\": {\n    \"coordinates\": [\n     [\n      [\n       \"<number>\",\n       \"<number>\"\n      ],\n      [\n       \"<number>\",\n       \"<number>\"\n      ],\n      [\n       \"<number>\",\n       \"<number>\"\n      ],\n      [\n       \"<number>\",\n       \"<number>\"\n      ]\n     ],\n     [\n      [\n       \"<number>\",\n       \"<number>\"\n      ],\n      [\n       \"<number>\",\n       \"<number>\"\n      ],\n      [\n       \"<number>\",\n       \"<number>\"\n      ],\n      [\n       \"<number>\",\n       \"<number>\"\n      ]\n     ]\n    ],\n    \"type\": \"<string>\"\n   },\n   \"multivlak\": {\n    \"coordinates\": [\n     [\n      [\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ]\n      ],\n      [\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ]\n      ]\n     ],\n     [\n      [\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ]\n      ],\n      [\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ]\n      ]\n     ]\n    ],\n    \"type\": \"<string>\"\n   }\n  }\n }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "5580210c-16ac-4fcf-95f1-deb8af354c29",
+                    "name": "Bad Request",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "woonplaatsen",
+                                ":woonplaatsidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "expand",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "woonplaatsidentificatie"
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "Accept-Crs",
+                                "value": "<string>",
+                                "description": "Gewenste CRS van de coördinaten in de response."
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request\",\n \"title\": \"Ten minste één parameter moet worden opgegeven.\",\n \"status\": 400,\n \"detail\": \"The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"paramsRequired\",\n \"invalidParams\": [\n  {\n   \"type\": \"https://www.vng.nl/realisatie/api/validaties/integer\",\n   \"name\": \"verblijfplaats__huisnummer\",\n   \"code\": \"integer\",\n   \"reason\": \"Waarde is geen geldige integer.\"\n  }\n ]\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "d10a0666-7b13-4f42-869d-c8688a4e3f60",
+                    "name": "Unauthorized",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "woonplaatsen",
+                                ":woonplaatsidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "expand",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "woonplaatsidentificatie"
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "Accept-Crs",
+                                "value": "<string>",
+                                "description": "Gewenste CRS van de coördinaten in de response."
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized\",\n \"title\": \"Niet correct geauthenticeerd.\",\n \"status\": 401,\n \"detail\": \"The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"authentication\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "d2dc1f52-f711-494d-a75f-88a2109d9cf6",
+                    "name": "Forbidden",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "woonplaatsen",
+                                ":woonplaatsidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "expand",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "woonplaatsidentificatie"
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "Accept-Crs",
+                                "value": "<string>",
+                                "description": "Gewenste CRS van de coördinaten in de response."
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Forbidden",
+                    "code": 403,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden\",\n \"title\": \"U bent niet geautoriseerd voor deze operatie.\",\n \"status\": 403,\n \"detail\": \"The server understood the request, but is refusing to fulfill it.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"autorisation\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "24aeb3e6-bda7-4403-a973-d6360fde9fc7",
+                    "name": "Not Found",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "woonplaatsen",
+                                ":woonplaatsidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "expand",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "woonplaatsidentificatie"
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "Accept-Crs",
+                                "value": "<string>",
+                                "description": "Gewenste CRS van de coördinaten in de response."
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Not Found",
+                    "code": 404,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found\",\n \"title\": \"Opgevraagde resource bestaat niet.\",\n \"status\": 404,\n \"detail\": \"The server has not found anything matching the Request-URI.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notFound\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "719149be-8cc8-4535-ae2a-20b57d0294ec",
+                    "name": "Not Acceptable",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "woonplaatsen",
+                                ":woonplaatsidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "expand",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "woonplaatsidentificatie"
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "Accept-Crs",
+                                "value": "<string>",
+                                "description": "Gewenste CRS van de coördinaten in de response."
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Not Acceptable",
+                    "code": 406,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable\",\n \"title\": \"Gevraagde contenttype wordt niet ondersteund.\",\n \"status\": 406,\n \"detail\": \"The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAcceptable\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "f7dfb3c1-c433-4eda-abdd-d174568c717a",
+                    "name": "Precondition failed",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "woonplaatsen",
+                                ":woonplaatsidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "expand",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "woonplaatsidentificatie"
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "Accept-Crs",
+                                "value": "<string>",
+                                "description": "Gewenste CRS van de coördinaten in de response."
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Precondition Failed",
+                    "code": 412,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.13 412 Precondition Failed\",\n \"title\": \"Precondition Failed\",\n \"status\": 412,\n \"detail\": \"The precondition given in one or more of the request-header fields evaluated to false when it was tested on the server.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"preconditionFailed\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "6c23f9fb-7957-4d79-9691-f9b47ca4ea68",
+                    "name": "Internal Server Error",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "woonplaatsen",
+                                ":woonplaatsidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "expand",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "woonplaatsidentificatie"
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "Accept-Crs",
+                                "value": "<string>",
+                                "description": "Gewenste CRS van de coördinaten in de response."
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Internal Server Error",
+                    "code": 500,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error\",\n \"title\": \"Interne server fout.\",\n \"status\": 500,\n \"detail\": \"The server encountered an unexpected condition which prevented it from fulfilling the request.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"serverError\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "7d33e666-7a31-4843-8f91-07cd223e67ae",
+                    "name": "Service Unavailable",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "woonplaatsen",
+                                ":woonplaatsidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "expand",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "woonplaatsidentificatie"
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "Accept-Crs",
+                                "value": "<string>",
+                                "description": "Gewenste CRS van de coördinaten in de response."
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Service Unavailable",
+                    "code": 503,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable\",\n \"title\": \"Bronservice {bron} is tijdelijk niet beschikbaar.\",\n \"status\": 503,\n \"detail\": \"The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAvailable\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "f236f930-5c13-46d7-86c8-8d55656efbac",
+                    "name": "Er is een onverwachte fout opgetreden",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "woonplaatsen",
+                                ":woonplaatsidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "expand",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "woonplaatsidentificatie"
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "Accept-Crs",
+                                "value": "<string>",
+                                "description": "Gewenste CRS van de coördinaten in de response."
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Internal Server Error",
+                    "code": 500,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"<uri>\",\n \"title\": \"<string>\",\n \"status\": \"<integer>\",\n \"detail\": \"<string>\",\n \"instance\": \"<uri>\",\n \"code\": \"<string>\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": []
+        },
+        {
+            "id": "13b5de8e-aee5-4b27-aef6-6559d00e09af",
+            "name": "levert BAG detals van een openbare ruimte",
+            "request": {
+                "name": "levert BAG detals van een openbare ruimte",
+                "description": {
+                    "content": "Raadpleeg een actuele openbare ruimte met de identificatie. Een openbare ruimte is een buitenruimte met een naam die binnen één woonplaats ligt, bijvoorbeeld een straat of een plein. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "openbareruimten",
+                        ":openbareruimteidentificatie"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [
+                        {
+                            "description": "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+                            "key": "fields",
+                            "value": "<string>"
+                        }
+                    ],
+                    "variable": [
+                        {
+                            "description": "(Required) Identificatie van een object uit de BAG. Deze is 4 lang bij een woonplaats en 16 lang bij de andere objecten.",
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "openbareruimteidentificatie"
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "X-Api-Key",
+                        "value": "",
+                        "description": "De API-key die je hebt gekregen dient bij elke request via de `X-Api-Key` request header meegestuurd te worden. Indien deze niet juist wordt meegestuurd, of het een ongeldige key betreft, zul je de foutmelding `403 Forbidden` terugkrijgen."
+                    }
+                ],
+                "method": "GET",
+                "auth": {
+                    "type": "noauth"
+                }
+            },
+            "response": [
+                {
+                    "id": "e123e07d-e3cf-4ce8-8268-e47531deeb80",
+                    "name": "Geslaagd",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "openbareruimten",
+                                ":openbareruimteidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "openbareruimteidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "warning",
+                            "value": "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie hier de documentatie: https://omgevingswet.../api/.../v1\".",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/hal+json"
+                        }
+                    ],
+                    "body": "{\n \"identificatie\": \"<string>\",\n \"domein\": \"<string>\",\n \"naam\": \"Laan van de landinrichtingscommissie Duiven-Westervoort\",\n \"type\": \"<string>\",\n \"status\": \"<string>\",\n \"korteNaam\": \"Ln vd l D-Westervoort\",\n \"geconstateerd\": \"<boolean>\",\n \"documentdatum\": {},\n \"documentnummer\": \"BAG-21\",\n \"woonplaatsIdentificatie\": \"2096\",\n \"mogelijkOnjuist\": {\n  \"naam\": \"<boolean>\",\n  \"korteNaam\": \"<boolean>\",\n  \"type\": \"<boolean>\",\n  \"status\": \"<boolean>\",\n  \"woonplaatsIdentificatie\": \"<boolean>\",\n  \"toelichting\": [\n   \"Openbare ruimtenaam komt mogelijk niet overeen met de vermelding in het straatnaambesluit.\",\n   \"Openbare ruimtenaam komt mogelijk niet overeen met de vermelding in het straatnaambesluit.\"\n  ]\n },\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  },\n  \"woonplaats\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  }\n }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "2d9c1662-c6f9-4837-aa92-3c0290cd2b0b",
+                    "name": "Bad Request",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "openbareruimten",
+                                ":openbareruimteidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "openbareruimteidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request\",\n \"title\": \"Ten minste één parameter moet worden opgegeven.\",\n \"status\": 400,\n \"detail\": \"The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"paramsRequired\",\n \"invalidParams\": [\n  {\n   \"type\": \"https://www.vng.nl/realisatie/api/validaties/integer\",\n   \"name\": \"verblijfplaats__huisnummer\",\n   \"code\": \"integer\",\n   \"reason\": \"Waarde is geen geldige integer.\"\n  }\n ]\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "b69d9108-f951-42df-81b0-a6e097b3fae9",
+                    "name": "Unauthorized",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "openbareruimten",
+                                ":openbareruimteidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "openbareruimteidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized\",\n \"title\": \"Niet correct geauthenticeerd.\",\n \"status\": 401,\n \"detail\": \"The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"authentication\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "4042e542-8f6f-4b6e-b77d-d9ece73363dc",
+                    "name": "Forbidden",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "openbareruimten",
+                                ":openbareruimteidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "openbareruimteidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Forbidden",
+                    "code": 403,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden\",\n \"title\": \"U bent niet geautoriseerd voor deze operatie.\",\n \"status\": 403,\n \"detail\": \"The server understood the request, but is refusing to fulfill it.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"autorisation\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "3ea90e68-68ed-4932-9b58-32e9dee43953",
+                    "name": "Not Found",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "openbareruimten",
+                                ":openbareruimteidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "openbareruimteidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Not Found",
+                    "code": 404,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found\",\n \"title\": \"Opgevraagde resource bestaat niet.\",\n \"status\": 404,\n \"detail\": \"The server has not found anything matching the Request-URI.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notFound\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "2a93e234-99f1-477e-88c8-ebff60e16d01",
+                    "name": "Not Acceptable",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "openbareruimten",
+                                ":openbareruimteidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "openbareruimteidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Not Acceptable",
+                    "code": 406,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable\",\n \"title\": \"Gevraagde contenttype wordt niet ondersteund.\",\n \"status\": 406,\n \"detail\": \"The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAcceptable\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "7ed41c17-dde6-48f9-8a5d-5146ab052c60",
+                    "name": "Internal Server Error",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "openbareruimten",
+                                ":openbareruimteidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "openbareruimteidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Internal Server Error",
+                    "code": 500,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error\",\n \"title\": \"Interne server fout.\",\n \"status\": 500,\n \"detail\": \"The server encountered an unexpected condition which prevented it from fulfilling the request.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"serverError\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "da937339-a616-4387-91b8-0c804ee8ee52",
+                    "name": "Service Unavailable",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "openbareruimten",
+                                ":openbareruimteidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "openbareruimteidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Service Unavailable",
+                    "code": 503,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable\",\n \"title\": \"Bronservice {bron} is tijdelijk niet beschikbaar.\",\n \"status\": 503,\n \"detail\": \"The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAvailable\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "0904c940-7df0-4c7c-aaa1-93f94a9131c8",
+                    "name": "Er is een onverwachte fout opgetreden",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "openbareruimten",
+                                ":openbareruimteidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "openbareruimteidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Internal Server Error",
+                    "code": 500,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"<uri>\",\n \"title\": \"<string>\",\n \"status\": \"<integer>\",\n \"detail\": \"<string>\",\n \"instance\": \"<uri>\",\n \"code\": \"<string>\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": []
+        },
+        {
+            "id": "52aabee2-29d8-49c1-8de0-053479a1f01b",
+            "name": "levert BAG details van een nummeraanduiding",
+            "request": {
+                "name": "levert BAG details van een nummeraanduiding",
+                "description": {
+                    "content": "Raadpleeg een actuele nummeraanduiding met de identificatie. Een nummeraanduiding is een postcode, huisnummer met evt een huisletter en huisnummertoevoeging die hoort bij een verblijfsobject, een standplaats of een ligplaats. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "nummeraanduidingen",
+                        ":nummeraanduidingidentificatie"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [
+                        {
+                            "description": "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+                            "key": "fields",
+                            "value": "<string>"
+                        }
+                    ],
+                    "variable": [
+                        {
+                            "description": "(Required) Identificatie van een nummeraanduiding uit de BAG. Deze is 16 cijfers lang.",
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "nummeraanduidingidentificatie"
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "X-Api-Key",
+                        "value": "",
+                        "description": "De API-key die je hebt gekregen dient bij elke request via de `X-Api-Key` request header meegestuurd te worden. Indien deze niet juist wordt meegestuurd, of het een ongeldige key betreft, zul je de foutmelding `403 Forbidden` terugkrijgen."
+                    }
+                ],
+                "method": "GET",
+                "auth": {
+                    "type": "noauth"
+                }
+            },
+            "response": [
+                {
+                    "id": "69e07ce7-1364-4173-8169-600bf93bdd62",
+                    "name": "Geslaagd",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "nummeraanduidingen",
+                                ":nummeraanduidingidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "nummeraanduidingidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "warning",
+                            "value": "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie hier de documentatie: https://omgevingswet.../api/.../v1\".",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/hal+json"
+                        }
+                    ],
+                    "body": "{\n \"identificatie\": \"<string>\",\n \"domein\": \"<string>\",\n \"huisnummer\": 1,\n \"huisletter\": \"A\",\n \"huisnummertoevoeging\": \"bis\",\n \"postcode\": \"6922KZ\",\n \"status\": \"<string>\",\n \"geconstateerd\": \"<boolean>\",\n \"documentdatum\": {},\n \"documentnummer\": \"Duiven 25112019\",\n \"woonplaatsIdentificatie\": \"2096\",\n \"openbareRuimteIdentificatie\": \"0226300000136166\",\n \"mogelijkOnjuist\": {\n  \"huisnummer\": \"<boolean>\",\n  \"huisletter\": \"<boolean>\",\n  \"huisnummertoevoeging\": \"<boolean>\",\n  \"postcode\": \"<boolean>\",\n  \"status\": \"<boolean>\",\n  \"woonplaatsIdentificatie\": \"<boolean>\",\n  \"openbareRuimteIdentificatie\": \"<boolean>\",\n  \"toelichting\": [\n   \"Woonplaats bestaat mogelijk niet.\",\n   \"Woonplaats bestaat mogelijk niet.\"\n  ]\n },\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  },\n  \"adres\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  },\n  \"openbareRuimte\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  },\n  \"woonplaats\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  }\n }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "27330cee-cd04-40b7-ac9d-84e8b74ffca6",
+                    "name": "Bad Request",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "nummeraanduidingen",
+                                ":nummeraanduidingidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "nummeraanduidingidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request\",\n \"title\": \"Ten minste één parameter moet worden opgegeven.\",\n \"status\": 400,\n \"detail\": \"The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"paramsRequired\",\n \"invalidParams\": [\n  {\n   \"type\": \"https://www.vng.nl/realisatie/api/validaties/integer\",\n   \"name\": \"verblijfplaats__huisnummer\",\n   \"code\": \"integer\",\n   \"reason\": \"Waarde is geen geldige integer.\"\n  }\n ]\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "cca07194-3829-45d4-9a3b-803b0b69105e",
+                    "name": "Unauthorized",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "nummeraanduidingen",
+                                ":nummeraanduidingidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "nummeraanduidingidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized\",\n \"title\": \"Niet correct geauthenticeerd.\",\n \"status\": 401,\n \"detail\": \"The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"authentication\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "f18a1dcc-0c83-4bb3-9eb9-e5ecfa45e549",
+                    "name": "Forbidden",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "nummeraanduidingen",
+                                ":nummeraanduidingidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "nummeraanduidingidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Forbidden",
+                    "code": 403,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden\",\n \"title\": \"U bent niet geautoriseerd voor deze operatie.\",\n \"status\": 403,\n \"detail\": \"The server understood the request, but is refusing to fulfill it.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"autorisation\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "34d63ab4-ff12-4ef4-b3dd-1c1083836625",
+                    "name": "Not Found",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "nummeraanduidingen",
+                                ":nummeraanduidingidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "nummeraanduidingidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Not Found",
+                    "code": 404,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found\",\n \"title\": \"Opgevraagde resource bestaat niet.\",\n \"status\": 404,\n \"detail\": \"The server has not found anything matching the Request-URI.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notFound\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "76687001-35b7-4cda-902f-c961fc2218ed",
+                    "name": "Not Acceptable",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "nummeraanduidingen",
+                                ":nummeraanduidingidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "nummeraanduidingidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Not Acceptable",
+                    "code": 406,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable\",\n \"title\": \"Gevraagde contenttype wordt niet ondersteund.\",\n \"status\": 406,\n \"detail\": \"The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAcceptable\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "91174908-8de2-4a06-83d5-8f0c367aff9c",
+                    "name": "Internal Server Error",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "nummeraanduidingen",
+                                ":nummeraanduidingidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "nummeraanduidingidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Internal Server Error",
+                    "code": 500,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error\",\n \"title\": \"Interne server fout.\",\n \"status\": 500,\n \"detail\": \"The server encountered an unexpected condition which prevented it from fulfilling the request.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"serverError\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "cda438d7-1217-4ee4-b885-cb541b6a4b21",
+                    "name": "Service Unavailable",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "nummeraanduidingen",
+                                ":nummeraanduidingidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "nummeraanduidingidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Service Unavailable",
+                    "code": 503,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable\",\n \"title\": \"Bronservice {bron} is tijdelijk niet beschikbaar.\",\n \"status\": 503,\n \"detail\": \"The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAvailable\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "0bd87c78-6cb0-406d-b7b8-16eedbf8e567",
+                    "name": "Er is een onverwachte fout opgetreden",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "nummeraanduidingen",
+                                ":nummeraanduidingidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "key": "nummeraanduidingidentificatie"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Internal Server Error",
+                    "code": 500,
+                    "header": [
+                        {
+                            "key": "api-version",
+                            "value": "1.0.0",
+                            "description": ""
+                        },
+                        {
+                            "key": "Content-Type",
+                            "value": "application/problem+json"
+                        }
+                    ],
+                    "body": "{\n \"type\": \"<uri>\",\n \"title\": \"<string>\",\n \"status\": \"<integer>\",\n \"detail\": \"<string>\",\n \"instance\": \"<uri>\",\n \"code\": \"<string>\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": []
+        },
+        {
+            "id": "7920a44f-189f-48d0-a462-4ecfba553821",
+            "name": "panden",
+            "item": [
+                {
+                    "id": "ed7933ef-a72e-4074-8c01-8f0aab99b539",
+                    "name": "vindt panden",
+                    "request": {
+                        "name": "vindt panden",
+                        "description": {
+                            "content": "Zoek actuele panden met de identificatie van een adresseerbaar object of een locatie. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature).",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "panden"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "description": "De identificatie van een adresserbaar object uit de BAG. Dit kan een verblijfsobject, een standplaats of een ligplaats zijn.",
+                                    "key": "adresseerbaarObjectIdentificatie",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "description": "Coordinaten van een locatie die als query-parmeter gebruikt wordt om een object te zoeken. Let op, explode is false dus het formaat is ?locatie=194602.722,464154.308",
+                                    "key": "locatie",
+                                    "value": "<number>,<number>"
+                                },
+                                {
+                                    "description": "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "X-Api-Key",
+                                "value": "",
+                                "description": "De API-key die je hebt gekregen dient bij elke request via de `X-Api-Key` request header meegestuurd te worden. Indien deze niet juist wordt meegestuurd, of het een ongeldige key betreft, zul je de foutmelding `403 Forbidden` terugkrijgen."
+                            },
+                            {
+                                "key": "Accept-Crs",
+                                "value": "<string>",
+                                "description": "Gewenste CRS van de coördinaten in de response."
+                            },
+                            {
+                                "key": "Content-Crs",
+                                "value": "<string>",
+                                "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                            }
+                        ],
+                        "method": "GET",
+                        "auth": {
+                            "type": "noauth"
+                        }
+                    },
+                    "response": [
+                        {
+                            "id": "ca04e75c-bb0b-4da8-a6dd-d5186b327ec7",
+                            "name": "Geslaagd",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "locatie",
+                                            "value": "196733.51,439931.89"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    },
+                                    {
+                                        "key": "Content-Crs",
+                                        "value": "<string>",
+                                        "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "warning",
+                                    "value": "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie hier de documentatie: https://omgevingswet.../api/.../v1\".",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Crs",
+                                    "value": "<string>",
+                                    "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/hal+json"
+                                }
+                            ],
+                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  }\n },\n \"_embedded\": {\n  \"panden\": [\n   {\n    \"identificatie\": \"<string>\",\n    \"domein\": \"<string>\",\n    \"geometrie\": {\n     \"coordinates\": [\n      [\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ]\n      ],\n      [\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ]\n      ]\n     ],\n     \"type\": \"<string>\"\n    },\n    \"oorspronkelijkBouwjaar\": 1991,\n    \"status\": \"<string>\",\n    \"geconstateerd\": \"<boolean>\",\n    \"documentdatum\": {},\n    \"documentnummer\": \"09.BW.0273\",\n    \"adresseerbaarObjectIdentificaties\": [\n     \"0226010000038820\",\n     \"0226010000038820\"\n    ],\n    \"nummeraanduidingIdentificaties\": [\n     {\n      \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n      \"isNevenadres\": \"<boolean>\"\n     },\n     {\n      \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n      \"isNevenadres\": \"<boolean>\"\n     }\n    ],\n    \"mogelijkOnjuist\": {\n     \"geometrie\": \"<boolean>\",\n     \"oorspronkelijkBouwjaar\": \"<boolean>\",\n     \"status\": \"<boolean>\",\n     \"toelichting\": [\n      \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\",\n      \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\"\n     ]\n    },\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"adressen\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ],\n     \"adresseerbareObjecten\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"<string>\",\n    \"domein\": \"<string>\",\n    \"geometrie\": {\n     \"coordinates\": [\n      [\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ]\n      ],\n      [\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ],\n       [\n        \"<number>\",\n        \"<number>\"\n       ]\n      ]\n     ],\n     \"type\": \"<string>\"\n    },\n    \"oorspronkelijkBouwjaar\": 1991,\n    \"status\": \"<string>\",\n    \"geconstateerd\": \"<boolean>\",\n    \"documentdatum\": {},\n    \"documentnummer\": \"09.BW.0273\",\n    \"adresseerbaarObjectIdentificaties\": [\n     \"0226010000038820\",\n     \"0226010000038820\"\n    ],\n    \"nummeraanduidingIdentificaties\": [\n     {\n      \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n      \"isNevenadres\": \"<boolean>\"\n     },\n     {\n      \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n      \"isNevenadres\": \"<boolean>\"\n     }\n    ],\n    \"mogelijkOnjuist\": {\n     \"geometrie\": \"<boolean>\",\n     \"oorspronkelijkBouwjaar\": \"<boolean>\",\n     \"status\": \"<boolean>\",\n     \"toelichting\": [\n      \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\",\n      \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\"\n     ]\n    },\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": \"<boolean>\",\n      \"title\": \"<string>\"\n     },\n     \"adressen\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ],\n     \"adresseerbareObjecten\": [\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      },\n      {\n       \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n       \"templated\": \"<boolean>\",\n       \"title\": \"<string>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "650283c9-c76b-4713-b666-3057ff117ec6",
+                            "name": "Bad Request",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "locatie",
+                                            "value": "196733.51,439931.89"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    },
+                                    {
+                                        "key": "Content-Crs",
+                                        "value": "<string>",
+                                        "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request\",\n \"title\": \"Ten minste één parameter moet worden opgegeven.\",\n \"status\": 400,\n \"detail\": \"The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"paramsRequired\",\n \"invalidParams\": [\n  {\n   \"type\": \"https://www.vng.nl/realisatie/api/validaties/integer\",\n   \"name\": \"verblijfplaats__huisnummer\",\n   \"code\": \"integer\",\n   \"reason\": \"Waarde is geen geldige integer.\"\n  }\n ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "260c1bed-738f-418f-96a4-ab98ce05f90b",
+                            "name": "Unauthorized",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "locatie",
+                                            "value": "196733.51,439931.89"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    },
+                                    {
+                                        "key": "Content-Crs",
+                                        "value": "<string>",
+                                        "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized\",\n \"title\": \"Niet correct geauthenticeerd.\",\n \"status\": 401,\n \"detail\": \"The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"authentication\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "fb324aff-b8e3-401a-948d-f97253dcdfa7",
+                            "name": "Forbidden",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "locatie",
+                                            "value": "196733.51,439931.89"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    },
+                                    {
+                                        "key": "Content-Crs",
+                                        "value": "<string>",
+                                        "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden\",\n \"title\": \"U bent niet geautoriseerd voor deze operatie.\",\n \"status\": 403,\n \"detail\": \"The server understood the request, but is refusing to fulfill it.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"autorisation\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "59a8a7dd-d7c9-4e62-af56-900b239f284c",
+                            "name": "Not Acceptable",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "locatie",
+                                            "value": "196733.51,439931.89"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    },
+                                    {
+                                        "key": "Content-Crs",
+                                        "value": "<string>",
+                                        "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Acceptable",
+                            "code": 406,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable\",\n \"title\": \"Gevraagde contenttype wordt niet ondersteund.\",\n \"status\": 406,\n \"detail\": \"The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAcceptable\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "c657c210-70ef-453a-abbf-9a020704af25",
+                            "name": "Precondition failed",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "locatie",
+                                            "value": "196733.51,439931.89"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    },
+                                    {
+                                        "key": "Content-Crs",
+                                        "value": "<string>",
+                                        "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Precondition Failed",
+                            "code": 412,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.13 412 Precondition Failed\",\n \"title\": \"Precondition Failed\",\n \"status\": 412,\n \"detail\": \"The precondition given in one or more of the request-header fields evaluated to false when it was tested on the server.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"preconditionFailed\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "7a1d860f-8d29-4170-a73c-f5b9e932bda4",
+                            "name": "Unsupported Media Type",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "locatie",
+                                            "value": "196733.51,439931.89"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    },
+                                    {
+                                        "key": "Content-Crs",
+                                        "value": "<string>",
+                                        "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unsupported Media Type",
+                            "code": 415,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type\",\n \"title\": \"Unsupported Media Type\",\n \"status\": 415,\n \"detail\": \"The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"unsupported\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "98dbc828-22a6-432e-a2ec-8bb9f5388b8b",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "locatie",
+                                            "value": "196733.51,439931.89"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    },
+                                    {
+                                        "key": "Content-Crs",
+                                        "value": "<string>",
+                                        "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error\",\n \"title\": \"Interne server fout.\",\n \"status\": 500,\n \"detail\": \"The server encountered an unexpected condition which prevented it from fulfilling the request.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"serverError\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "e8e5b6a1-9e9a-4d29-b4ac-6773e2d87553",
+                            "name": "Service Unavailable",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "locatie",
+                                            "value": "196733.51,439931.89"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    },
+                                    {
+                                        "key": "Content-Crs",
+                                        "value": "<string>",
+                                        "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Service Unavailable",
+                            "code": 503,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable\",\n \"title\": \"Bronservice {bron} is tijdelijk niet beschikbaar.\",\n \"status\": 503,\n \"detail\": \"The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAvailable\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "04aeef2e-370d-4f91-9773-61bfb15d206e",
+                            "name": "Er is een onverwachte fout opgetreden",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "adresseerbaarObjectIdentificatie",
+                                            "value": "0226010000038820"
+                                        },
+                                        {
+                                            "key": "locatie",
+                                            "value": "196733.51,439931.89"
+                                        },
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    },
+                                    {
+                                        "key": "Content-Crs",
+                                        "value": "<string>",
+                                        "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"<uri>\",\n \"title\": \"<string>\",\n \"status\": \"<integer>\",\n \"detail\": \"<string>\",\n \"instance\": \"<uri>\",\n \"code\": \"<string>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": []
+                },
+                {
+                    "id": "a0b9522d-41e8-4f50-a2ef-6f44a9bc0c6d",
+                    "name": "levert een pand",
+                    "request": {
+                        "name": "levert een pand",
+                        "description": {
+                            "content": "Raadpleeg een actueel pand met de identificatie. Een pand is een bouwkundige, constructief zelfstandige eenheid die direct en duurzaam met de aarde is verbonden en betreedbaar en afsluitbaar is. Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, zie [functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature).",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "panden",
+                                ":pandidentificatie"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "description": "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature)",
+                                    "key": "fields",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "description": "(Required) Identificatie van een pand uit de BAG. Deze is 16 cijfers lang.",
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "pandidentificatie"
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "X-Api-Key",
+                                "value": "",
+                                "description": "De API-key die je hebt gekregen dient bij elke request via de `X-Api-Key` request header meegestuurd te worden. Indien deze niet juist wordt meegestuurd, of het een ongeldige key betreft, zul je de foutmelding `403 Forbidden` terugkrijgen."
+                            },
+                            {
+                                "key": "Accept-Crs",
+                                "value": "<string>",
+                                "description": "Gewenste CRS van de coördinaten in de response."
+                            }
+                        ],
+                        "method": "GET",
+                        "auth": {
+                            "type": "noauth"
+                        }
+                    },
+                    "response": [
+                        {
+                            "id": "a054b6ad-eb26-461b-8676-34de6ee1a6a5",
+                            "name": "Geslaagd",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden",
+                                        ":pandidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "pandidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "warning",
+                                    "value": "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie hier de documentatie: https://omgevingswet.../api/.../v1\".",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Crs",
+                                    "value": "<string>",
+                                    "description": "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel."
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/hal+json"
+                                }
+                            ],
+                            "body": "{\n \"identificatie\": \"<string>\",\n \"domein\": \"<string>\",\n \"geometrie\": {\n  \"coordinates\": [\n   [\n    [\n     \"<number>\",\n     \"<number>\"\n    ],\n    [\n     \"<number>\",\n     \"<number>\"\n    ],\n    [\n     \"<number>\",\n     \"<number>\"\n    ],\n    [\n     \"<number>\",\n     \"<number>\"\n    ]\n   ],\n   [\n    [\n     \"<number>\",\n     \"<number>\"\n    ],\n    [\n     \"<number>\",\n     \"<number>\"\n    ],\n    [\n     \"<number>\",\n     \"<number>\"\n    ],\n    [\n     \"<number>\",\n     \"<number>\"\n    ]\n   ]\n  ],\n  \"type\": \"<string>\"\n },\n \"oorspronkelijkBouwjaar\": 1991,\n \"status\": \"<string>\",\n \"geconstateerd\": \"<boolean>\",\n \"documentdatum\": {},\n \"documentnummer\": \"09.BW.0273\",\n \"adresseerbaarObjectIdentificaties\": [\n  \"0226010000038820\",\n  \"0226010000038820\"\n ],\n \"nummeraanduidingIdentificaties\": [\n  {\n   \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n   \"isNevenadres\": \"<boolean>\"\n  },\n  {\n   \"nummeraanduidingIdentificatie\": \"0226200000038923\",\n   \"isNevenadres\": \"<boolean>\"\n  }\n ],\n \"mogelijkOnjuist\": {\n  \"geometrie\": \"<boolean>\",\n  \"oorspronkelijkBouwjaar\": \"<boolean>\",\n  \"status\": \"<boolean>\",\n  \"toelichting\": [\n   \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\",\n   \"Mogelijk is de bouw al gereed of is het pand niet gerealiseerd.\"\n  ]\n },\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": \"<boolean>\",\n   \"title\": \"<string>\"\n  },\n  \"adressen\": [\n   {\n    \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n    \"templated\": \"<boolean>\",\n    \"title\": \"<string>\"\n   },\n   {\n    \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n    \"templated\": \"<boolean>\",\n    \"title\": \"<string>\"\n   }\n  ],\n  \"adresseerbareObjecten\": [\n   {\n    \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n    \"templated\": \"<boolean>\",\n    \"title\": \"<string>\"\n   },\n   {\n    \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n    \"templated\": \"<boolean>\",\n    \"title\": \"<string>\"\n   }\n  ]\n }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "7e98f503-f447-4f27-804a-a88ff4a55c12",
+                            "name": "Bad Request",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden",
+                                        ":pandidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "pandidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request\",\n \"title\": \"Ten minste één parameter moet worden opgegeven.\",\n \"status\": 400,\n \"detail\": \"The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"paramsRequired\",\n \"invalidParams\": [\n  {\n   \"type\": \"https://www.vng.nl/realisatie/api/validaties/integer\",\n   \"name\": \"verblijfplaats__huisnummer\",\n   \"code\": \"integer\",\n   \"reason\": \"Waarde is geen geldige integer.\"\n  }\n ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "4db9d72d-d097-4db4-ba7c-aa39d9519cb2",
+                            "name": "Unauthorized",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden",
+                                        ":pandidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "pandidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized\",\n \"title\": \"Niet correct geauthenticeerd.\",\n \"status\": 401,\n \"detail\": \"The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"authentication\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "90f2b46f-6061-4548-a381-21844014a2df",
+                            "name": "Forbidden",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden",
+                                        ":pandidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "pandidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden\",\n \"title\": \"U bent niet geautoriseerd voor deze operatie.\",\n \"status\": 403,\n \"detail\": \"The server understood the request, but is refusing to fulfill it.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"autorisation\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "5628ecf4-38d1-4826-a520-59e98943b7e0",
+                            "name": "Not Found",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden",
+                                        ":pandidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "pandidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found\",\n \"title\": \"Opgevraagde resource bestaat niet.\",\n \"status\": 404,\n \"detail\": \"The server has not found anything matching the Request-URI.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notFound\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "7bbccfb0-bd0f-4f16-9d1f-7905b6994432",
+                            "name": "Not Acceptable",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden",
+                                        ":pandidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "pandidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Acceptable",
+                            "code": 406,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable\",\n \"title\": \"Gevraagde contenttype wordt niet ondersteund.\",\n \"status\": 406,\n \"detail\": \"The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAcceptable\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "cf01712c-83d7-4c1c-a380-59a193c132ab",
+                            "name": "Precondition failed",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden",
+                                        ":pandidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "pandidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Precondition Failed",
+                            "code": 412,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.13 412 Precondition Failed\",\n \"title\": \"Precondition Failed\",\n \"status\": 412,\n \"detail\": \"The precondition given in one or more of the request-header fields evaluated to false when it was tested on the server.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"preconditionFailed\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "a4430b2d-6fb7-4957-8e9c-78d2b3594687",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden",
+                                        ":pandidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "pandidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error\",\n \"title\": \"Interne server fout.\",\n \"status\": 500,\n \"detail\": \"The server encountered an unexpected condition which prevented it from fulfilling the request.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"serverError\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "25521fa6-1df2-483a-9a53-c07b07318a39",
+                            "name": "Service Unavailable",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden",
+                                        ":pandidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "pandidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Service Unavailable",
+                            "code": 503,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable\",\n \"title\": \"Bronservice {bron} is tijdelijk niet beschikbaar.\",\n \"status\": 503,\n \"detail\": \"The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"notAvailable\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "97713429-16fb-44bb-a0a0-c556b5cf9dbc",
+                            "name": "Er is een onverwachte fout opgetreden",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "panden",
+                                        ":pandidentificatie"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "fields",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": [
+                                        {
+                                            "type": "any",
+                                            "key": "pandidentificatie"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept-Crs",
+                                        "value": "<string>",
+                                        "description": "Gewenste CRS van de coördinaten in de response."
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "api-version",
+                                    "value": "1.0.0",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/problem+json"
+                                }
+                            ],
+                            "body": "{\n \"type\": \"<uri>\",\n \"title\": \"<string>\",\n \"status\": \"<integer>\",\n \"detail\": \"<string>\",\n \"instance\": \"<uri>\",\n \"code\": \"<string>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": []
+                }
+            ],
+            "event": []
+        }
+    ],
+    "event": [],
+    "variable": [
+        {
+            "id": "baseUrl",
+            "type": "string",
+            "value": "https://api.bag.acceptatie.kadaster.nl/esd/huidigebevragingen/v1"
+        }
+    ],
+    "auth": {
+        "type": "noauth"
+    },
+    "info": {
+        "_postman_id": "fdc2de7b-5d01-4f5c-8595-02aebe28efd0",
+        "name": "Huidige bevragingen API",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        "description": {
+            "content": "Deze API levert actuele gegevens over adressen, adresseerbaar objecten en panden. Actueel betekent in deze API `zonder eindstatus`. De bron voor deze API is de basisregistratie adressen en gebouwen (BAG).\n\nContact Support:\n Name: Kadaster - Beheerder Landelijke Voorziening BAG\n Email: bag@kadaster.nl",
+            "type": "text/plain"
+        }
+    }
+}


### PR DESCRIPTION
1. Verwijderen zoeken van panden op nummeraanduidingIdentificatie (zit nog niet in release 1.0.0).

2. Verwijderen response headers X-pagination-limit en X-pagination-page.
In implementatie worden nu (release 1.0.0) andere headers geleverd (X_pagination_limit en X_pagination_page), zie #310. 

3. Response header Content-Crs verwijderd bij /adressen en /adressen/{nummeraanduidingIdentificatie}. Er zit geen geometrie in deze responses.

4. Inconsistente naamgeving 200 responses opgelost. Heet nu overal "Geslaagd".

5. Postman collection voor de API toegevoegd (gegenereerd van API specificaties)

6. genereervariant ook in json versie toegevoegd