### PR TITLE
toevoegen adresregels aan adres resource

### DIFF
--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -686,6 +686,14 @@ components:
       - $ref: "#/components/schemas/Adres"
       - description: "Het adres is de benaming van een locatie bestaande uit straatnaam, huisnummer, (mogelijk met huisletter, huisnummertoevoeging, postcode) en woonplaatsnaam. Dit is de vereenvoudigde samenstelling van de officiële naamgeving gebaseerd op woonplaats, openbare ruimte en nummeraanduiding."
         properties:
+          adresregel1:
+            type: "string"
+            description: "De eerste regel van het adres zoals deze gebruikt kan worden in postadressering."
+            example: "Ln vd l D-Westervoort 1A-bis"
+          adresregel2:
+            type: "string"
+            description: "De tweede regel van het adres zoals deze gebruikt kan worden in postadressering."
+            example: "6922KZ Duiven"
           korteNaam:
             description: "De officiële openbareruimtenaam of een verkorte versie. Beiden hebben maximaal 24 tekens."
             type: string


### PR DESCRIPTION
fixes #360

Op verzoek van Cathy deze pull request naar develop gemaakt. Hiermee wordt, op dezelfde manier als in de Haal Centraal BRP API adresregel1 en adresregel2 toegevoegd, zodat een gebruiker het samengestelde adres direct en correct kan gebruiken.