### PR TITLE
verwijderen minLength en maxLength voor parameters zoek en zoekresultaatIdentificatie

### DIFF
--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -48,8 +48,6 @@
             "style": "form",
             "explode": true,
             "schema": {
-              "maxLength": 255,
-              "minLength": 1,
               "type": "string"
             }
           },
@@ -313,8 +311,6 @@
             "style": "form",
             "explode": true,
             "schema": {
-              "maxLength": 255,
-              "minLength": 1,
               "type": "string"
             }
           },
@@ -4136,8 +4132,6 @@
         "style": "form",
         "explode": true,
         "schema": {
-          "maxLength": 255,
-          "minLength": 1,
           "type": "string"
         }
       },
@@ -4149,8 +4143,6 @@
         "style": "form",
         "explode": true,
         "schema": {
-          "maxLength": 255,
-          "minLength": 1,
           "type": "string"
         }
       },

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -40,8 +40,6 @@ paths:
         style: form
         explode: true
         schema:
-          maxLength: 255
-          minLength: 1
           type: string
       - name: page
         in: query
@@ -244,8 +242,6 @@ paths:
         style: form
         explode: true
         schema:
-          maxLength: 255
-          minLength: 1
           type: string
       - name: expand
         in: query
@@ -3174,8 +3170,6 @@ components:
       style: form
       explode: true
       schema:
-        maxLength: 255
-        minLength: 1
         type: string
     zoekresultaatIdentificatie:
       name: zoekresultaatIdentificatie
@@ -3185,8 +3179,6 @@ components:
       style: form
       explode: true
       schema:
-        maxLength: 255
-        minLength: 1
         type: string
     locatie-query:
       name: locatie

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -502,8 +502,6 @@ components:
       required: true
       schema:
         type: string
-        minLength: 1
-        maxLength: 255
 
     zoekresultaatIdentificatie:
       description: "De identificatie van een zoekresultaat van het endpoint get /adressen/zoek."
@@ -512,8 +510,6 @@ components:
       required: false
       schema:
         type: string
-        minLength: 1
-        maxLength: 255
 
     locatie-query:
       description: Coordinaten van een locatie die als query-parameter gebruikt wordt om een object te zoeken. Let op, explode is false dus het formaat is ?locatie=194602.722,464154.308


### PR DESCRIPTION
n.a.v. #364 terugdraaien van het toevoegen van minLength en maxLength op parameters zoek en zoekresultaatIdentificatie, omdat:
1. deze toevoeging een breaking change is en dus niet in de v1 release mag worden doorgevoerd
2. deze toevoeging niet in de implementatie is doorgevoerd en dus nog niet in de master mag staan