### PR TITLE
Update Getting Started deprecated versie HC BAG API 1.5

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,7 +15,7 @@ nav:
         path: /goals-canvas
   - title: Haal Centraal BAG Huidige Bevragingen v. 1.5 (Deprecated)
     subnav:
-      - title: Getting started
+      - title: Functionaliteit en specificaties
         path: /getting-started
       - title: User stories
         path: /user-stories-prod

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,11 +4,13 @@ title: Functionaliteit en specificaties
 ---
 # Functionaliteit en specificaties - BAG Huidige Bevragingen API
 
+## <span style="color:red">De BAG Huidige Bevragingen API is deprecated en wordt met ingang van 1 juli a.s. niet meer ondersteund. Wij adviseren niet meer te starten met de implementatie van deze API en verwijzen je naar de BAG Individuele Bevragingen v. 2.6 die deze API gaat vervangen. Onderstaande informatie is alleen bedoelt voor de huidige gebruikers van deze API.
+
 Je kunt de Open API Specificaties (OAS3) van de API bekijken in [Swagger-formaat](./swagger-ui) of [Redoc](./redoc).
 
 De (resolved) OAS3 is hier te downloaden: [openapi.yaml](https://github.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/blob/master/specificatie/genereervariant/openapi.yaml){:target="_blank" rel="noopener"}.
 
-### Beschikbare resources
+## Beschikbare resources
 De API kent de volgende resources:
 - adressen: hierin zijn samenhangende en gerelateerde gegevens samengevoegd uit de nummeraanduiding, openbare ruimte en woonplaats die samen een adres vormen
 - adresseerbareobjecten: dit kan een verblijfsobject, ligplaats of standplaats zijn
@@ -20,7 +22,7 @@ De API kent de volgende resources:
 Voor de verschillende resources wordt de uri samengesteld met de identificatie van het onderliggende BAG-object. Dit is een 16 cijferige, of in geval van woonplaats 4 cijferige identificatie. Voor adressen wordt de nummeraanduiding identificatie gebruikt in de uri.  
 De identificatie kan voorloopnullen bevatten, dus het is geen integer.
 
-#### Zoeken van een adres
+### Zoeken van een adres
 Je kan een adres zoeken met endpoint /adressen/zoek en parameter "zoek" waarin met postcode, woonplaats, straatnaam, huisnummer, huisletter en huisnummertoevoeging kan worden gezocht. Op dit moment worden alleen deze gegevens ondersteund, het is de bedoeling dat dit later volledig "fuzzy search" wordt.  
 Deze zoekfunctie, via endpoint /adressen/zoek levert voor elk gevonden adres een combinatie van een zoekresultaat identificatie en een omschrijving, plus een link voor het ophalen van de volledige adresgegevens.
 
@@ -46,7 +48,7 @@ Bijvoorbeeld zoeken op "/adressen/zoek?zoek=nootdorp 15c dorpsstraat" levert:
 ```
 Het adres haal je vervolgens op met "/adressen?zoekresultaatIdentificatie=adr-89d5a4d96f09c60716c4671fdb9334b8".
 
-#### Zoeken van adressen in een pand
+### Zoeken van adressen in een pand
 Wanneer je alle adressen in een pand wilt zoeken, kan je dit doen met /adressen?pandIdentificatie={pandIdentificatie}, waarbij {pandIdentificatie} moet worden vervangen door de identificatie van het betreffende pand. Bijvoorbeeld /adressen?pandIdentificatie=0826100000000467.
 
 Aangezien dit veel adressen kan opleveren, wordt hier [paginering](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/paginering.feature){:target="_blank"} toegepast.
@@ -54,10 +56,10 @@ Aangezien dit veel adressen kan opleveren, wordt hier [paginering](https://githu
 Met dit endpoint kun je ook zoeken op postcode, huisnummer, huisletter en huisnummertoevoeging.
 De manier waarop je met de parameter exacteMatch kunt zoeken, kun je vinden in de feature.
 
-#### Geometrie van een woonplaats
+### Geometrie van een woonplaats
 De geometrie van een woonplaats kan zeer omvangrijk zijn. Daarom wordt de geometrie niet standaard met een woonplaats meegeleverd. Wanneer je de geometrie van de woonplaats wel wilt krijgen, dan moet je de expand parameter gebruiken. Bijvoorbeeld /woonplaatsen/2258?expand=geometrie.
 
-### Algemene functionaliteit
+## Algemene functionaliteit
 Verder zijn er nog een paar algemene functies die gelden voor alle bovenstaande aanvragen:
 - Gebruik van de **fields** parameter om de response te filteren. Voor werking, zie feature [fields](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/fields.feature){:target="_blank"}
 - Gebruik van de **expand** parameter om subresources te ontsluiten. Voor werking, zie feature [expand](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/expand.feature){:target="_blank"}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 ---
 layout: page-with-side-nav
-title: Getting Started
+title: Functionaliteit en specificaties
 ---
 # Functionaliteit en specificaties - BAG Huidige Bevragingen API
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,18 +2,8 @@
 layout: page-with-side-nav
 title: Getting Started
 ---
-# Getting Started - BAG Huidige Bevragingen API
+# Functionaliteit en specificaties - BAG Huidige Bevragingen API
 
-Om aan te sluiten kun je de volgende stappen doorlopen:
-1. [Aanmelden](#aanmelden) om toegang te krijgen tot de acceptatie- en productieomgeving
-2. Bekijk de [functionaliteit en specificaties](#functionaliteit-en-specificaties)
-3. [Implementeer de API Client](#implementeer-de-api-client)
-4. [Probeer en test de API](#probeer-en-test-de-api)
-
-## Aanmelden
-[Vraag een API key voor de productieomgeving aan](https://formulieren.kadaster.nl/aanvraag_bag_api_huidige_bevragingen_productie){:target="_blank"}. Testen doe je bij voorkeur in de productie-omgeving.
-
-## Functionaliteit en specificaties
 Je kunt de Open API Specificaties (OAS3) van de API bekijken in [Swagger-formaat](./swagger-ui) of [Redoc](./redoc).
 
 De (resolved) OAS3 is hier te downloaden: [openapi.yaml](https://github.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/blob/master/specificatie/genereervariant/openapi.yaml){:target="_blank" rel="noopener"}.
@@ -78,20 +68,7 @@ Verder zijn er nog een paar algemene functies die gelden voor alle bovenstaande 
 - Bij het zoeken naar panden en adresseerbare objecten kun je gebruik maken van bbox.
 - [HAL links](https://tools.ietf.org/html/draft-kelly-json-hal-08){:target="_blank"}, die soms [templated](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.1.0/features/uri-templating.feature){:target="_blank"} worden geleverd.
 
-## Implementeer de API client
-Client code kun je genereren met de "[genereervariant](https://github.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/blob/master/specificatie/genereervariant/openapi.yaml){:target="_blank" rel="noopener"}" van de API-specificaties en een code generator. Een overzicht met codegeneratoren kun je vinden op [OpenAPI.Tools](https://openapi.tools/#sdk){:target="_blank" rel="noopener"}.
-
-Deze repo bevat scripts waarmee je met [OpenAPI Generator](https://openapi-generator.tech/){:target="_blank" rel="noopener"} client code kunt genereren in JAVA, .NET (Full Framework & Core) en Python. De makkelijkste manier om de code generatie scripts te gebruiken, is door deze repo te clonen. Na het clonen kun je met `npm install` de benodigde packages installeren en kun je met npm run <script naam> één van de volgende scripts uitvoeren:
-- oas:generate-java-client (voor JAVA client code)
-- oas:generate-netcore-client (voor .NET Core client code)
-- oas:generate-net-client (voor .NET Full Framework client code)
-- oas:generate-python-client (voor Python client code)
-
-Een lijst met andere ondersteunde generator opties kun je vinden in de [Generators List](https://openapi-generator.tech/docs/generators){:target="_blank" rel="noopener"} van OpenAPI Generator.
-
-Note. De prerequisite van OpenAPI Generator is JAVA. Je moet een JAVA runtime installeren voordat je OpenAPI Generator kunt gebruiken
-
-## Probeer en test de API
+## Test de API
 De werking van de API is het makkelijkst te testen met behulp van [Postman](https://www.getpostman.com/){:target="_blank"}.
 De [openapi.yaml](https://github.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/blob/master/specificatie/genereervariant/openapi.yaml){:target="_blank"} kun je importeren als project, waarna de verschillende requests worden ingeladen die deze API ondersteunt.
 We hebben al een project voor je gemaakt die je kan gebruiken: [BAG-Bevragen-postman-collection.json](https://github.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/blob/master/test/BAG-Bevragen-postman-collection.json){:target="_blank"}. Hierin moet je alleen de base url en authenticatie (API-key) nog invullen.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,9 @@ title: Functionaliteit en specificaties
 ---
 # Functionaliteit en specificaties - BAG Huidige Bevragingen API
 
-## <span style="color:red">De BAG Huidige Bevragingen API is deprecated en wordt met ingang van 1 juli a.s. niet meer ondersteund. Wij adviseren niet meer te starten met de implementatie van deze API en verwijzen je naar de BAG Individuele Bevragingen v. 2.6 die deze API gaat vervangen. Onderstaande informatie is alleen bedoelt voor de huidige gebruikers van deze API.
+## <span style="color:red">De BAG Huidige Bevragingen API is deprecated en wordt met ingang van 1 juli a.s. niet meer ondersteund.</span>
+   
+<span style="color:red">Wij adviseren niet meer te starten met de implementatie van deze API en verwijzen je naar de [Getting Started van de BAG Individuele Bevragingen v. 2.6](https://vng-realisatie.github.io/Haal-Centraal-BAG-bevragen/getting-started-IB) die deze API gaat vervangen. Onderstaande informatie is alleen bedoelt voor de huidige gebruikers van deze API.</span>
 
 Je kunt de Open API Specificaties (OAS3) van de API bekijken in [Swagger-formaat](./swagger-ui) of [Redoc](./redoc).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,8 +78,7 @@ De [openapi.yaml](https://github.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/b
 We hebben al een project voor je gemaakt die je kan gebruiken: [BAG-Bevragen-postman-collection.json](https://github.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/blob/master/test/BAG-Bevragen-postman-collection.json){:target="_blank"}. Hierin moet je alleen de base url en authenticatie (API-key) nog invullen.
 
 ### API key
-Om de API te kunnen bevragen is een API key nodig. Deze moet je bij het request opnemen in request header "X-Api-Key".
-[Vraag een API key voor de productieomgeving aan](https://formulieren.kadaster.nl/aanvraag_bag_api_huidige_bevragingen_productie){:target="_blank"}.
+Om de API te kunnen bevragen is de API key nodig die je al eerder hebt ontvangen. Deze moet je bij het request opnemen in request header "X-Api-Key".
 
 ### Testgevallen
 Onderstaande tabellen bevatten testgevallen voor specifieke situaties waarmee de werking van de API kan worden getest.


### PR DESCRIPTION
We verwijzen nieuwe gebruikers naar versie 2.6 van de BAG Individuele Bevragingen API en adviseren hen niet meer te starten met de Haal Centraal BAG API 1.5 die deprecated is.